### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -25,6 +25,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-15
             target: aarch64-apple-darwin
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
 
     steps:
       - name: Resolve tag
@@ -48,10 +50,14 @@ jobs:
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
 
+      - name: Test
+        run: cargo test --locked --target ${{ matrix.target }}
+
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
 
-      - name: Package
+      - name: Package Unix
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
@@ -74,6 +80,25 @@ jobs:
             sha256sum "dist/${package}.tar.gz" > "dist/${package}.tar.gz.sha256"
           fi
 
+      - name: Package Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ steps.release.outputs.version }}"
+          $target = "${{ matrix.target }}"
+          $package = "music-tui-$version-$target"
+          $staging = "dist/$package"
+          $archive = "dist/$package.zip"
+
+          New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          Copy-Item "target/$target/release/music-tui.exe" $staging
+          Copy-Item LICENSE, README.md $staging
+          Copy-Item doc "$staging/doc" -Recurse
+          Compress-Archive -Path "$staging/*" -DestinationPath $archive -Force
+
+          $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          "$hash  $package.zip" | Set-Content -Encoding ascii "$archive.sha256"
+
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -81,5 +106,5 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
-          assets=(dist/*.tar.gz dist/*.sha256)
+          assets=(dist/*.tar.gz dist/*.zip dist/*.sha256)
           gh release upload "$TAG" "${assets[@]}" --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -686,6 +686,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -909,6 +930,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1219,11 +1251,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1383,7 +1425,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1429,6 +1471,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "dirs",
  "framework-tui",
  "hex",
  "image",
@@ -1507,7 +1550,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1606,6 +1649,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2245,6 +2294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,7 +2406,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2535,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2632,7 +2692,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2796,7 +2856,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3195,12 +3255,78 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 dirs = "5"
 rusqlite = { version = "0.32", default-features = false, features = ["column_decltype", "bundled"] }
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ unicode-width = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+dirs = "5"
+rusqlite = { version = "0.32", default-features = false, features = ["column_decltype", "bundled"] }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ cargo install --path .
 
 Requires `mpd`, `chafa` and `sqlite`.
 
+### Windows
+
+See [doc/windows.md](doc/windows.md) for MPD setup and Windows-specific
+notes. In short: install MPD, create a `mpd.conf` with
+`bind_to_address "127.0.0.1"`, register it as a Windows service
+(`sc.exe create mpd ...`), then run `music-tui`.
+
 ## Documentation
 
 [doc/index.md](doc/index.md).

--- a/doc/index.md
+++ b/doc/index.md
@@ -26,4 +26,5 @@ This directory contains the full user and configuration documentation for
 
 ## Operational Notes
 
+- [Windows](windows.md): MPD setup and platform differences on Windows.
 - [Troubleshooting](troubleshooting.md): connection, rendering, and fifo issues.

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -35,7 +35,7 @@ replace it with a real output (e.g. `sox`, `wasapi`) when you are ready.
 Register MPD so it starts automatically at boot and runs in the background:
 
 ```powershell
-sc.exe create mpd binPath= "\"C:\path\to\mpd.exe\" \"C:\path\to\mpd.conf\"" DisplayName= "Music Player Daemon" start= auto
+sc.exe create mpd binPath= '"C:\path\to\mpd.exe" "C:\path\to\mpd.conf"' DisplayName= "Music Player Daemon" start= auto
 ```
 
 Replace the paths with your actual `mpd.exe` and `mpd.conf` locations.

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -1,0 +1,109 @@
+# Windows
+
+`music-tui` runs on Windows via TCP. The MPD auto-bootstrap
+(first-run socket generation) is Unix-only; on Windows you must install
+and configure MPD yourself before launching music-tui.
+
+## Install MPD
+
+Download the Windows build from https://www.musicpd.org/download.html
+or install via [Chocolatey](https://community.chocolatey.org/packages/mpd):
+
+```powershell
+choco install mpd
+```
+
+## Create mpd.conf
+
+Create `mpd.conf` in a location MPD can find (e.g. the same directory as
+`mpd.exe`, or `%APPDATA%\mpd\mpd.conf`). A minimal config:
+
+```
+music_directory "C:/Users/<you>/Music"
+bind_to_address "127.0.0.1"
+port "6600"
+```
+
+Replace `<you>` with your Windows username. Adjust `music_directory` to
+point at your music library. The `null` audio output is a safe default;
+replace it with a real output (e.g. `sox`, `wasapi`) when you are ready.
+
+## Start MPD
+
+### As a Windows service (recommended)
+
+Register MPD so it starts automatically at boot and runs in the background:
+
+```powershell
+sc.exe create mpd binPath= "\"C:\path\to\mpd.exe\" \"C:\path\to\mpd.conf\"" DisplayName= "Music Player Daemon" start= auto
+```
+
+Replace the paths with your actual `mpd.exe` and `mpd.conf` locations.
+Then start it:
+
+```powershell
+net start mpd
+```
+
+Other commands:
+
+```powershell
+net stop mpd          # stop
+sc.exe delete mpd     # remove the service
+```
+
+You can also manage the service from `services.msc`.
+
+### Manual (console)
+
+```powershell
+mpd mpd.conf
+```
+
+This keeps a terminal occupied; useful for testing or debugging.
+
+### Verify MPD is running
+
+```powershell
+telnet 127.0.0.1 6600
+```
+
+You should see `OK MPD ...`.
+
+## Launch music-tui
+
+```powershell
+music-tui
+```
+
+Make sure `config.toml` uses the TCP host (this is the default):
+
+```toml
+[mpd]
+host = "127.0.0.1"
+port = 6600
+```
+
+## Differences from Unix
+
+| Feature                              | Unix               | Windows            |
+| ------------------------------------ | ------------------ | ------------------ |
+| MPD connection                       | Unix socket or TCP | TCP only           |
+| First-run MPD bootstrap              | Automatic          | Manual (see above) |
+| Spectrum visualizer (FIFO)           | Supported          | Not supported      |
+| File bridge (`open` outside library) | Symlink            | File copy          |
+
+## Troubleshooting
+
+**"connection refused" (os error 10061)**
+MPD is not running or not listening on the configured host/port. Start
+MPD and verify with `telnet 127.0.0.1 6600`.
+
+**"FIFO visualizer is not supported on Windows"**
+The visualizer reads MPD's fifo audio output, which is a Unix-only
+mechanism. Disable the visualizer tab or ignore the warning; all other
+features work normally.
+
+**SQLite not found during build**
+The Windows build uses the `bundled` rusqlite feature, which compiles
+SQLite from source automatically. No system SQLite install is needed.

--- a/src/app/outcomes.rs
+++ b/src/app/outcomes.rs
@@ -149,6 +149,7 @@ impl App {
     handled || self.tab_contains(PaneKind::Cover)
   }
 
+  #[cfg(unix)]
   pub fn handle_spectrum(&mut self, bars: Vec<u8>) -> bool {
     self.spectrum = bars;
     self.request_visualizer_frame();

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -14,22 +14,43 @@ pub(super) fn app_state_dir() -> PathBuf {
   platform_state_dir().join("music-tui")
 }
 
+#[cfg(unix)]
 fn platform_state_dir() -> PathBuf {
   env_path("XDG_STATE_HOME")
     .or_else(|| env_path("HOME").map(|home| home.join(".local/state")))
     .unwrap_or_else(|| PathBuf::from(".local/state"))
 }
 
+#[cfg(windows)]
+fn platform_state_dir() -> PathBuf {
+  dirs::data_dir()
+    .unwrap_or_else(|| PathBuf::from("."))
+}
+
+#[cfg(unix)]
 pub(super) fn platform_config_dir() -> PathBuf {
   env_path("XDG_CONFIG_HOME")
     .or_else(|| env_path("HOME").map(|home| home.join(".config")))
     .unwrap_or_else(|| PathBuf::from(".config"))
 }
 
+#[cfg(windows)]
+pub(super) fn platform_config_dir() -> PathBuf {
+  dirs::config_dir()
+    .unwrap_or_else(|| PathBuf::from("."))
+}
+
+#[cfg(unix)]
 pub(super) fn platform_cache_dir() -> PathBuf {
   env_path("XDG_CACHE_HOME")
     .or_else(|| env_path("HOME").map(|home| home.join(".cache")))
     .unwrap_or_else(|| PathBuf::from(".cache"))
+}
+
+#[cfg(windows)]
+pub(super) fn platform_cache_dir() -> PathBuf {
+  dirs::cache_dir()
+    .unwrap_or_else(|| PathBuf::from("."))
 }
 
 pub(super) fn env_path(name: &str) -> Option<PathBuf> {
@@ -39,10 +60,16 @@ pub(super) fn env_path(name: &str) -> Option<PathBuf> {
 }
 
 pub fn expand_home(path: &str) -> PathBuf {
-  if let Some(rest) = path.strip_prefix("~/")
-    && let Some(home) = env_path("HOME") {
+  if let Some(rest) = path.strip_prefix("~/") {
+    #[cfg(unix)]
+    if let Some(home) = env_path("HOME") {
       return home.join(rest);
     }
+    #[cfg(windows)]
+    if let Some(home) = env_path("USERPROFILE") {
+      return home.join(rest);
+    }
+  }
   PathBuf::from(path)
 }
 
@@ -65,11 +92,21 @@ pub fn detect_music_dir() -> Option<PathBuf> {
   None
 }
 
+#[cfg(unix)]
 pub(super) fn mpd_config_paths() -> Vec<PathBuf> {
   let mut paths = vec![platform_config_dir().join("mpd").join("mpd.conf")];
   if let Some(home) = env_path("HOME") {
     paths.push(home.join(".mpd").join("mpd.conf"));
     paths.push(home.join(".mpdconf"));
+  }
+  paths
+}
+
+#[cfg(windows)]
+pub(super) fn mpd_config_paths() -> Vec<PathBuf> {
+  let mut paths = vec![platform_config_dir().join("mpd").join("mpd.conf")];
+  if let Some(appdata) = env_path("APPDATA") {
+    paths.push(appdata.join("mpd").join("mpd.conf"));
   }
   paths
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -222,16 +222,22 @@ impl LayoutConfig {
   }
 
   fn with_default_tabs() -> Self {
+    let tabs = vec![
+      TabConfig::playlist(),
+      TabConfig::library(),
+      TabConfig::playing(),
+      TabConfig::metadata(),
+      TabConfig::lyrics(),
+    ];
+    #[cfg(unix)]
+    let tabs = {
+      let mut tabs = tabs;
+      tabs.push(TabConfig::visualizer());
+      tabs
+    };
     Self {
       detail: layout::DEFAULT_DETAIL_LAYOUT.to_string(),
-      tabs: vec![
-        TabConfig::playlist(),
-        TabConfig::library(),
-        TabConfig::playing(),
-        TabConfig::metadata(),
-        TabConfig::lyrics(),
-        TabConfig::visualizer(),
-      ],
+      tabs,
     }
   }
 }
@@ -290,6 +296,7 @@ impl TabConfig {
     }
   }
 
+  #[cfg(unix)]
   fn visualizer() -> Self {
     Self {
       name: "visualizer".to_string(),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -102,7 +102,14 @@ pub struct VisualizerConfig {
 impl Default for VisualizerConfig {
   fn default() -> Self {
     Self {
+      #[cfg(unix)]
       fifo_path: "/tmp/mpd.fifo".to_string(),
+      #[cfg(windows)]
+      fifo_path: {
+        let mut p = std::env::temp_dir();
+        p.push("mpd.fifo");
+        p.to_string_lossy().into_owned()
+      },
       sample_rate: 44100,
       channels: 2,
       bars: 256,

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,6 +15,7 @@ pub enum AsyncEvent {
   MetadataWrite(MetadataWriteOutcome),
   Cover(CoverOutcome),
   Render(RenderOutcome),
+  #[cfg(unix)]
   Spectrum(Vec<u8>),
   /// Precomputed visualizer pane lines from the band-render worker.
   VisualizerFrame(Vec<ratatui::text::Line<'static>>),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -260,7 +260,10 @@ mod tests {
   #[test]
   fn default_config_parses() {
     let tabs = parse_tabs(&LayoutConfig::default()).expect("default layouts");
+    #[cfg(unix)]
     assert_eq!(tabs.len(), 6);
+    #[cfg(windows)]
+    assert_eq!(tabs.len(), 5);
     assert_eq!(tabs[0].main, PaneKind::Queue);
     assert!(tabs[0].layout.contains(PaneKind::Cover));
     assert!(tabs[0].layout.contains(PaneKind::Metadata));

--- a/src/library.rs
+++ b/src/library.rs
@@ -122,8 +122,11 @@ pub fn same_song_uri(left: &str, right: &str) -> bool {
 
 /// True when the host selects a UNIX socket connection — the only
 /// transport MPD accepts `file://` uris on.
-pub fn is_socket_host(host: &str) -> bool {
-  expand_home(host).to_string_lossy().starts_with('/')
+pub fn is_socket_host(_host: &str) -> bool {
+  #[cfg(unix)]
+  { expand_home(_host).to_string_lossy().starts_with('/') }
+  #[cfg(not(unix))]
+  { false }
 }
 
 /// Prefix an absolute path as a `file://` uri for MPD. MPD's local-file
@@ -184,6 +187,21 @@ pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
       }
       return Err(error).with_context(|| format!("failed to publish {}", link.display()));
     }
+  }
+  #[cfg(not(unix))]
+  {
+    // Windows: symlink_file requires admin or developer mode; fallback to copy
+    if link.exists() {
+      let same_size = std::fs::metadata(&link)
+        .ok()
+        .zip(std::fs::metadata(target).ok())
+        .is_some_and(|(a, b)| a.len() == b.len());
+      if same_size {
+        return Ok(link);
+      }
+    }
+    std::fs::copy(target, &link)
+      .with_context(|| format!("failed to copy {} -> {}", target.display(), link.display()))?;
   }
   Ok(link)
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -155,8 +155,8 @@ pub fn links_dir(music_dir: &Path, configured: &str) -> PathBuf {
   }
 }
 
-/// Ensure a symlink under `dir` pointing at `target` (reused when intact);
-/// returns the link path. MPD follows outside symlinks by default.
+/// Ensure a bridge entry under `dir` for `target` (reused when current).
+/// Unix uses a symlink; Windows uses an atomically published cached copy.
 pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
   use sha2::{Digest, Sha256};
   std::fs::create_dir_all(dir)
@@ -188,22 +188,91 @@ pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
       return Err(error).with_context(|| format!("failed to publish {}", link.display()));
     }
   }
-  #[cfg(not(unix))]
+  #[cfg(windows)]
   {
-    // Windows: symlink_file requires admin or developer mode; fallback to copy
-    if link.exists() {
-      let same_size = std::fs::metadata(&link)
-        .ok()
-        .zip(std::fs::metadata(target).ok())
-        .is_some_and(|(a, b)| a.len() == b.len());
-      if same_size {
+    // Windows symlinks require admin or developer mode, so publish a copy.
+    // Comparing modification time as well as size prevents stale same-size
+    // files from being reused after the source is edited.
+    if same_file_version(&link, target) {
+      return Ok(link);
+    }
+
+    let temp = dir.join(format!(
+      ".{hash}-{}.{}.tmp",
+      name.to_string_lossy(),
+      std::process::id(),
+    ));
+    let _ = std::fs::remove_file(&temp);
+
+    // Retry once when the source changes while it is being copied. The
+    // stable bridge name is replaced only after a complete copy exists.
+    for attempt in 0..2 {
+      std::fs::copy(target, &temp)
+        .with_context(|| format!("failed to copy {} -> {}", target.display(), temp.display()))?;
+      if !same_file_version(&temp, target) {
+        let _ = std::fs::remove_file(&temp);
+        if attempt == 0 {
+          continue;
+        }
+        bail!("{} changed while it was being copied", target.display());
+      }
+
+      if let Err(error) = replace_file(&temp, &link) {
+        let _ = std::fs::remove_file(&temp);
+        // A concurrent instance may have published the same version first.
+        if same_file_version(&link, target) {
+          return Ok(link);
+        }
+        return Err(error).with_context(|| format!("failed to publish {}", link.display()));
+      }
+      if same_file_version(&link, target) {
         return Ok(link);
       }
+      if attempt == 0 {
+        continue;
+      }
+      bail!("{} changed while its bridge copy was published", target.display());
     }
-    std::fs::copy(target, &link)
-      .with_context(|| format!("failed to copy {} -> {}", target.display(), link.display()))?;
   }
   Ok(link)
+}
+
+#[cfg(windows)]
+fn same_file_version(left: &Path, right: &Path) -> bool {
+  std::fs::metadata(left)
+    .ok()
+    .zip(std::fs::metadata(right).ok())
+    .is_some_and(|(left, right)| {
+      left.len() == right.len()
+        && left
+          .modified()
+          .ok()
+          .zip(right.modified().ok())
+          .is_some_and(|(left, right)| left == right)
+    })
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+  use std::os::windows::ffi::OsStrExt;
+  use windows_sys::Win32::Storage::FileSystem::{
+    MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+  };
+
+  let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+  let destination: Vec<u16> = destination.as_os_str().encode_wide().chain(Some(0)).collect();
+  let moved = unsafe {
+    MoveFileExW(
+      source.as_ptr(),
+      destination.as_ptr(),
+      MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+    )
+  };
+  if moved == 0 {
+    Err(std::io::Error::last_os_error())
+  } else {
+    Ok(())
+  }
 }
 
 #[cfg(test)]
@@ -219,6 +288,7 @@ mod tests {
     assert_eq!(configured_music_dir(&config), None);
   }
 
+  #[cfg(unix)]
   #[test]
   fn file_uri_resolves_without_music_dir() {
     let path = Path::new("/tmp/音乐/100% a song.flac");
@@ -235,6 +305,28 @@ mod tests {
       uri_to_path(Some(Path::new("/music")), "Artist/song.flac"),
       Some(PathBuf::from("/music/Artist/song.flac")),
     );
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn bridge_copy_refreshes_after_same_size_edit() {
+    let root = std::env::temp_dir().join(format!("music-tui-bridge-{}", std::process::id()));
+    let source = root.join("source.mp3");
+    let bridge = root.join("bridge");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(&source, b"first").unwrap();
+
+    let linked = ensure_link(&bridge, &source).unwrap();
+    assert_eq!(std::fs::read(&linked).unwrap(), b"first");
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::fs::write(&source, b"other").unwrap();
+    let refreshed = ensure_link(&bridge, &source).unwrap();
+    assert_eq!(refreshed, linked);
+    assert_eq!(std::fs::read(&refreshed).unwrap(), b"other");
+
+    let _ = std::fs::remove_dir_all(&root);
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,9 @@ async fn run_tui(
   let mpd = mpd::spawn_mpd_worker(settings.config.mpd.clone(), tx.clone());
   mpd.set_queue_dedup(settings.config.behavior.queue_dedup);
   let visualizer = visualizer::spawn_visualizer(settings.config.visualizer.clone(), tx.clone());
-  let band_renderer = visualizer::spawn_band_renderer(tx.clone());
+  let band_renderer = visualizer
+    .as_ref()
+    .map(|_| visualizer::spawn_band_renderer(tx.clone()));
   let library_scan_tx = spawn_library_scanner(
     &settings.config.library,
     &settings.state_dir,
@@ -128,8 +130,8 @@ async fn run_tui(
   let mut renderer = CoverRenderStore::new(render_config, native_config, render_modes);
   let mut tui = Tui::new(protocol_reset)?;
   let mut app = App::new(settings, mpd, tx.clone(), initial_notice, interrupt);
-  app.visualizer = Some(visualizer.clone());
-  app.visualizer_renderer = Some(band_renderer);
+  app.visualizer = visualizer.clone();
+  app.visualizer_renderer = band_renderer;
   app.library_scan_tx = library_scan_tx;
   app.restore_state(state::PersistedState::load(&app.settings.state_dir));
   let mut saved_state = app.snapshot_state();
@@ -178,7 +180,9 @@ async fn run_tui(
       saved_state = current_state;
     }
   }
-  visualizer.stop();
+  if let Some(visualizer) = visualizer {
+    visualizer.stop();
+  }
   tui.restore()?;
   let final_state = app.snapshot_state();
   if final_state != saved_state {
@@ -210,6 +214,7 @@ fn handle_async_event(
     AsyncEvent::MetadataWrite(outcome) => app.handle_metadata_write_outcome(outcome),
     AsyncEvent::Cover(outcome) => app.handle_cover_outcome(outcome),
     AsyncEvent::Render(outcome) => renderer.finish(outcome),
+    #[cfg(unix)]
     AsyncEvent::Spectrum(bars) => app.handle_spectrum(bars),
     AsyncEvent::VisualizerFrame(lines) => app.handle_visualizer_frame(lines),
     AsyncEvent::Library(event) => match event {

--- a/src/mpd/mod.rs
+++ b/src/mpd/mod.rs
@@ -142,6 +142,8 @@ pub fn spawn_mpd_worker(
 
 pub async fn connect(config: &MpdConfig) -> anyhow::Result<(Client, mpd_client::client::ConnectionEvents)> {
   let host = crate::config::expand_home(&config.host);
+
+  #[cfg(unix)]
   if host.to_string_lossy().starts_with('/') {
     let stream = tokio::net::UnixStream::connect(&host).await?;
     let (client, events) = Client::connect_with_password_opt(stream, config.password.as_deref())
@@ -158,11 +160,11 @@ pub async fn connect(config: &MpdConfig) -> anyhow::Result<(Client, mpd_client::
 }
 
 fn describe_address(config: &MpdConfig) -> String {
+  #[cfg(unix)]
   if config.host.starts_with('/') {
-    config.host.clone()
-  } else {
-    format!("{}:{}", config.host, config.port)
+    return config.host.clone();
   }
+  format!("{}:{}", config.host, config.port)
 }
 
 mod interrupt;

--- a/src/open.rs
+++ b/src/open.rs
@@ -423,6 +423,7 @@ mod tests {
     }
   }
 
+  #[cfg(unix)]
   #[test]
   fn socket_uses_file_uri_without_music_dir() {
     let path = Path::new("/tmp/Music/a song.flac");

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -128,28 +128,36 @@ mod tests {
 
   #[test]
   fn parses_m3u_with_comments_and_relative_entries() {
+    let absolute = std::env::temp_dir().join("music-tui-absolute.mp3");
     let path = write_tmp(
       "list.m3u",
-      "#EXTM3U\n#EXTINF:123,Artist - Title\n../songs/a.flac\n/somewhere/b.mp3\n\n\n",
+      &format!(
+        "#EXTM3U\n#EXTINF:123,Artist - Title\n../songs/a.flac\n{}\n\n\n",
+        absolute.display(),
+      ),
     );
     let entries = parse_playlist(&path).unwrap();
     assert_eq!(entries.len(), 2);
     assert!(entries[0].ends_with("../songs/a.flac"));
-    assert_eq!(entries[1], PathBuf::from("/somewhere/b.mp3"));
+    assert_eq!(entries[1], absolute);
     let _ = std::fs::remove_file(&path);
     cleanup_tmp();
   }
 
   #[test]
   fn parses_pls_file_entries_only() {
+    let absolute = std::env::temp_dir().join("music-tui-absolute.flac");
     let path = write_tmp(
       "list.pls",
-      "[playlist]\nFile1=one.ogg\nTitle1=x\nFile2=/abs/two.flac\nLength1=10\n",
+      &format!(
+        "[playlist]\nFile1=one.ogg\nTitle1=x\nFile2={}\nLength1=10\n",
+        absolute.display(),
+      ),
     );
     let entries = parse_playlist(&path).unwrap();
     assert_eq!(entries.len(), 2);
     assert!(entries[0].ends_with("one.ogg"));
-    assert_eq!(entries[1], PathBuf::from("/abs/two.flac"));
+    assert_eq!(entries[1], absolute);
     let _ = std::fs::remove_file(&path);
     cleanup_tmp();
   }
@@ -192,12 +200,13 @@ mod tests {
 
   #[test]
   fn save_path_rejects_relative_paths() {
-    let dir = Path::new("/state/playlists");
-    assert!(resolve_save_path(Some("sub/queue.m3u"), dir).is_err());
-    assert!(resolve_save_path(Some("../queue.m3u"), dir).is_err());
+    let dir = std::env::temp_dir().join("music-tui-playlists");
+    assert!(resolve_save_path(Some("sub/queue.m3u"), &dir).is_err());
+    assert!(resolve_save_path(Some("../queue.m3u"), &dir).is_err());
+    let absolute = std::env::temp_dir().join("music-tui-queue.m3u");
     assert_eq!(
-      resolve_save_path(Some("/abs/queue.m3u"), dir).unwrap(),
-      PathBuf::from("/abs/queue.m3u")
+      resolve_save_path(Some(absolute.to_str().unwrap()), &dir).unwrap(),
+      absolute,
     );
     cleanup_tmp();
   }

--- a/src/ui/visualizer.rs
+++ b/src/ui/visualizer.rs
@@ -14,6 +14,16 @@ pub(super) fn draw_visualizer_pane(frame: &mut Frame, app: &mut App, area: Rect)
     return;
   }
 
+  if app.visualizer.is_none() {
+    let theme = &app.settings.theme;
+    frame.render_widget(
+      Paragraph::new("spectrum visualizer is unavailable on this platform")
+        .style(Style::default().fg(theme.color(&theme.base.muted))),
+      inner,
+    );
+    return;
+  }
+
   // Keep the analysis band count in sync with the pane width, and let the
   // app re-render the band lines off-thread when the geometry changes.
   if let Some(visualizer) = app.visualizer.as_ref() {

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -6,14 +6,19 @@
 mod render;
 
 use std::{
-  io::{Read, Result as IoResult},
   sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize, Ordering},
   },
+};
+
+#[cfg(unix)]
+use std::{
+  io::{Read, Result as IoResult},
   time::{Duration, Instant},
 };
 
+#[cfg(unix)]
 use rustfft::{Fft, FftPlanner, num_complex::Complex};
 use tokio::sync::mpsc;
 
@@ -54,6 +59,7 @@ impl VisualizerHandle {
 /// every band owns at least one distinct bin, so neighboring low-frequency
 /// bands (where a pure log grid is narrower than the FFT resolution) never
 /// sample the same bin and render as duplicated identical bars.
+#[cfg(unix)]
 fn band_edges(hint: usize, hz_per_bin: f32, min_freq: f32, max_freq: f32) -> Vec<f32> {
   let hint = hint.max(2);
   let mut edges =
@@ -74,6 +80,7 @@ fn band_edges(hint: usize, hz_per_bin: f32, min_freq: f32, max_freq: f32) -> Vec
   edges
 }
 
+#[cfg(unix)]
 fn build_band_edges(ratio: f32, hz_per_bin: f32, min_freq: f32, max_freq: f32) -> Vec<f32> {
   let mut edges = vec![min_freq];
   loop {
@@ -89,6 +96,7 @@ fn build_band_edges(ratio: f32, hz_per_bin: f32, min_freq: f32, max_freq: f32) -
 
 /// Map band edges to FFT bin ranges `[start, end)`; every range contains
 /// at least one bin and consecutive ranges are disjoint.
+#[cfg(unix)]
 fn band_bin_ranges(edges: &[f32], window: usize, sample_rate: u32) -> Vec<(usize, usize)> {
   let bins = window / 2;
   let nyquist = sample_rate as f32 / 2.0;
@@ -113,10 +121,11 @@ fn band_bin_ranges(edges: &[f32], window: usize, sample_rate: u32) -> Vec<(usize
     })
 }
 
+#[cfg(unix)]
 pub fn spawn_visualizer(
   config: VisualizerConfig,
   events: mpsc::UnboundedSender<AsyncEvent>,
-) -> VisualizerHandle {
+) -> Option<VisualizerHandle> {
   let stop = Arc::new(AtomicBool::new(false));
   // Until the UI reports a pane width, analyze at the configured cap.
   let columns = Arc::new(AtomicUsize::new(config.bars.max(1)));
@@ -130,9 +139,18 @@ pub fn spawn_visualizer(
       run(config, events, stop, columns);
     })
     .expect("failed to spawn visualizer thread");
-  handle
+  Some(handle)
 }
 
+#[cfg(not(unix))]
+pub fn spawn_visualizer(
+  _config: VisualizerConfig,
+  _events: mpsc::UnboundedSender<AsyncEvent>,
+) -> Option<VisualizerHandle> {
+  None
+}
+
+#[cfg(unix)]
 fn run(
   config: VisualizerConfig,
   events: mpsc::UnboundedSender<AsyncEvent>,
@@ -250,59 +268,48 @@ fn run(
 }
 
 /// Resolved band colors handed to the render worker.
-fn open_fifo(_path: &str) -> IoResult<std::fs::File> {
-  #[cfg(windows)]
+#[cfg(unix)]
+fn open_fifo(path: &str) -> IoResult<std::fs::File> {
+  use std::os::fd::AsRawFd;
+  use std::os::unix::fs::OpenOptionsExt;
+  // mpd only creates the fifo when it loads its config; anything that
+  // wipes it afterwards (e.g. a /tmp cleaner) leaves both sides stranded
+  // until the fifo exists again. Recreate it so mpd can reconnect on its
+  // next output open.
+  if !std::path::Path::new(path).exists()
+    && let Ok(cpath) = std::ffi::CString::new(path)
   {
-    let _ = _path;
-    return Err(std::io::Error::new(
-      std::io::ErrorKind::Unsupported,
-      "FIFO visualizer is not supported on Windows; configure MPD with a TCP-capable audio output",
-    ));
+    unsafe { libc::mkfifo(cpath.as_ptr(), 0o666) };
+    // Ignore mkfifo errors: a racing creator (or a bad path) surfaces
+    // as the open error below.
   }
-
-  #[cfg(unix)]
-  {
-    let path = _path;
-    use std::os::fd::AsRawFd;
-    use std::os::unix::fs::OpenOptionsExt;
-    // mpd only creates the fifo when it loads its config; anything that
-    // wipes it afterwards (e.g. a /tmp cleaner) leaves both sides stranded
-    // until the fifo exists again. Recreate it so mpd can reconnect on its
-    // next output open.
-    if !std::path::Path::new(path).exists()
-      && let Ok(cpath) = std::ffi::CString::new(path)
-    {
-      unsafe { libc::mkfifo(cpath.as_ptr(), 0o666) };
-      // Ignore mkfifo errors: a racing creator (or a bad path) surfaces
-      // as the open error below.
+  let file = std::fs::OpenOptions::new()
+    .read(true)
+    .write(true)
+    .custom_flags(libc::O_NONBLOCK)
+    .open(path)?;
+  // The fifo stream is single-consumer: if a second music-tui instance
+  // (or any other reader) opened it first, the kernel would split the
+  // samples between both readers and garble every spectrum. An exclusive
+  // advisory lock on the fifo makes the loser back off cleanly. The lock
+  // lives on the open file description and is released on close/drop.
+  let locked = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+  if locked != 0 {
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+      tracing::info!("visualizer fifo {path} is held by another instance; backing off");
+      return Err(std::io::Error::new(
+        std::io::ErrorKind::ResourceBusy,
+        format!("fifo {path} is already read by another instance"),
+      ));
     }
-    let file = std::fs::OpenOptions::new()
-      .read(true)
-      .write(true)
-      .custom_flags(libc::O_NONBLOCK)
-      .open(path)?;
-    // The fifo stream is single-consumer: if a second music-tui instance
-    // (or any other reader) opened it first, the kernel would split the
-    // samples between both readers and garble every spectrum. An exclusive
-    // advisory lock on the fifo makes the loser back off cleanly. The lock
-    // lives on the open file description and is released on close/drop.
-    let locked = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    if locked != 0 {
-      let error = std::io::Error::last_os_error();
-      if error.kind() == std::io::ErrorKind::WouldBlock {
-        tracing::info!("visualizer fifo {path} is held by another instance; backing off");
-        return Err(std::io::Error::new(
-          std::io::ErrorKind::ResourceBusy,
-          format!("fifo {path} is already read by another instance"),
-        ));
-      }
-      return Err(error);
-    }
-    tracing::info!("visualizer locked fifo {path}");
-    Ok(file)
+    return Err(error);
   }
+  tracing::info!("visualizer locked fifo {path}");
+  Ok(file)
 }
 
+#[cfg(unix)]
 fn compute_spectrum(
   frame: &[f32],
   fft: &Arc<dyn Fft<f32>>,
@@ -331,7 +338,7 @@ fn compute_spectrum(
   values
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
   use super::*;
 

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -250,44 +250,57 @@ fn run(
 }
 
 /// Resolved band colors handed to the render worker.
-fn open_fifo(path: &str) -> IoResult<std::fs::File> {
-  use std::os::fd::AsRawFd;
-  use std::os::unix::fs::OpenOptionsExt;
-  // mpd only creates the fifo when it loads its config; anything that
-  // wipes it afterwards (e.g. a /tmp cleaner) leaves both sides stranded
-  // until the fifo exists again. Recreate it so mpd can reconnect on its
-  // next output open.
-  if !std::path::Path::new(path).exists()
-    && let Ok(cpath) = std::ffi::CString::new(path)
+fn open_fifo(_path: &str) -> IoResult<std::fs::File> {
+  #[cfg(windows)]
   {
-    unsafe { libc::mkfifo(cpath.as_ptr(), 0o666) };
-    // Ignore mkfifo errors: a racing creator (or a bad path) surfaces
-    // as the open error below.
+    let _ = _path;
+    return Err(std::io::Error::new(
+      std::io::ErrorKind::Unsupported,
+      "FIFO visualizer is not supported on Windows; configure MPD with a TCP-capable audio output",
+    ));
   }
-  let file = std::fs::OpenOptions::new()
-    .read(true)
-    .write(true)
-    .custom_flags(libc::O_NONBLOCK)
-    .open(path)?;
-  // The fifo stream is single-consumer: if a second music-tui instance
-  // (or any other reader) opened it first, the kernel would split the
-  // samples between both readers and garble every spectrum. An exclusive
-  // advisory lock on the fifo makes the loser back off cleanly. The lock
-  // lives on the open file description and is released on close/drop.
-  let locked = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-  if locked != 0 {
-    let error = std::io::Error::last_os_error();
-    if error.kind() == std::io::ErrorKind::WouldBlock {
-      tracing::info!("visualizer fifo {path} is held by another instance; backing off");
-      return Err(std::io::Error::new(
-        std::io::ErrorKind::ResourceBusy,
-        format!("fifo {path} is already read by another instance"),
-      ));
+
+  #[cfg(unix)]
+  {
+    let path = _path;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+    // mpd only creates the fifo when it loads its config; anything that
+    // wipes it afterwards (e.g. a /tmp cleaner) leaves both sides stranded
+    // until the fifo exists again. Recreate it so mpd can reconnect on its
+    // next output open.
+    if !std::path::Path::new(path).exists()
+      && let Ok(cpath) = std::ffi::CString::new(path)
+    {
+      unsafe { libc::mkfifo(cpath.as_ptr(), 0o666) };
+      // Ignore mkfifo errors: a racing creator (or a bad path) surfaces
+      // as the open error below.
     }
-    return Err(error);
+    let file = std::fs::OpenOptions::new()
+      .read(true)
+      .write(true)
+      .custom_flags(libc::O_NONBLOCK)
+      .open(path)?;
+    // The fifo stream is single-consumer: if a second music-tui instance
+    // (or any other reader) opened it first, the kernel would split the
+    // samples between both readers and garble every spectrum. An exclusive
+    // advisory lock on the fifo makes the loser back off cleanly. The lock
+    // lives on the open file description and is released on close/drop.
+    let locked = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if locked != 0 {
+      let error = std::io::Error::last_os_error();
+      if error.kind() == std::io::ErrorKind::WouldBlock {
+        tracing::info!("visualizer fifo {path} is held by another instance; backing off");
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::ResourceBusy,
+          format!("fifo {path} is already read by another instance"),
+        ));
+      }
+      return Err(error);
+    }
+    tracing::info!("visualizer locked fifo {path}");
+    Ok(file)
   }
-  tracing::info!("visualizer locked fifo {path}");
-  Ok(file)
 }
 
 fn compute_spectrum(


### PR DESCRIPTION
## What

Adds Windows platform support for music-tui, allowing it to run on Windows with MPD's TCP transport.

## Changes

- `src/mpd/mod.rs`: Guard Unix socket connection with `#[cfg(unix)]`, TCP used on both platforms
- `src/library.rs`: `is_socket_host()` returns `false` on Windows; `ensure_link()` falls back to file copy (symlink requires admin)
- `src/visualizer/mod.rs`: Disable FIFO visualizer on Windows (MPD rarely uses FIFO output there)
- `src/config/paths.rs`: Use `dirs` crate for config/cache/state paths on Windows (replacing XDG)
- `src/config/schema.rs`: Platform-aware default FIFO path
- `Cargo.toml`: Add `dirs` (Windows), `rusqlite` bundled (Windows only)
- `doc/windows.md`: New file — MPD install, config, service setup, troubleshooting

## Known limitations (Windows)

- Spectrum visualizer is disabled (FIFO is a Unix-only mechanism)
- File bridge for `open` uses file copy instead of symlink (no admin required)
- MPD auto-bootstrap (first-run socket generation) is Unix-only; Windows users must install MPD manually

## Testing

- Compiled successfully on Windows 
- `cargo check` passes with zero warnings (on `music-tui` crate)

Note: Linux/macOS builds are untested in this PR.