### PR TITLE
fix: harden vs panic, fifo perms, and atomic config writes

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -254,6 +254,7 @@ impl App {
       return;
     };
     if let Ok(index) = target.parse::<usize>()
+      && index > 0
       && self.goto_tab(index - 1)
     {
       return;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -322,7 +322,7 @@ fn toml_semantic_value(body: &str) -> Option<toml::Value> {
 }
 
 pub async fn write_bytes_atomic(path: &Path, body: &[u8]) -> Result<()> {
-  let temp = path.with_extension("tmp");
+  let temp = path.with_extension(format!("tmp.{}", std::process::id()));
   fs::write(&temp, body)
     .await
     .with_context(|| format!("failed to write {}", temp.display()))?;

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -279,7 +279,7 @@ fn open_fifo(path: &str) -> IoResult<std::fs::File> {
   if !std::path::Path::new(path).exists()
     && let Ok(cpath) = std::ffi::CString::new(path)
   {
-    unsafe { libc::mkfifo(cpath.as_ptr(), 0o666) };
+    unsafe { libc::mkfifo(cpath.as_ptr(), 0o600) };
     // Ignore mkfifo errors: a racing creator (or a bad path) surfaces
     // as the open error below.
   }


### PR DESCRIPTION
Three small hardening/defect fixes from a source review of the
`music-tui` codebase:

- **commands**: guard `:tab 0` from a debug-build `usize` underflow in
  `index - 1` (previously panicked in debug builds; a no-op in release).
- **visualizer**: create the MPD output FIFO with `0600` instead of
  `0666` so it is not world-writable.
- **config**: pid-suffix the staging temp file in `write_bytes_atomic`
  so concurrent instances cannot clobber each other's temp file before
  `rename` (matches the scheme already used for state saves).

Verified: `cargo build` and `cargo test` pass (54 tests). This branch
contains only this one commit, based on current upstream `main`.
