### PR TITLE
fix: safe interrupt restore, folder open guard, and goto_playing row mapping

### DIFF
--- a/src/app/detail.rs
+++ b/src/app/detail.rs
@@ -108,9 +108,11 @@ impl App {
     let row = self
       .queue_filter_matches
       .iter()
-      .position(|candidate| *candidate == position.0.0)
-      .unwrap_or(position.0.0);
-    self.select_queue_row(row);
+      .position(|candidate| *candidate == position.0.0);
+    match row {
+      Some(row) => self.select_queue_row(row),
+      None => self.set_message("the playing song is hidden by the current filter"),
+    }
     true
   }
 }

--- a/src/mpd/worker.rs
+++ b/src/mpd/worker.rs
@@ -4,6 +4,10 @@
 use super::*;
 struct SessionState {
   interrupt: Option<InterruptSession>,
+  /// How many times a pending interrupt restore has failed; used to bound
+  /// automatic retries so a permanently missing saved playlist does not
+  /// spin forever (the playlist is preserved for manual recovery).
+  restore_attempts: u32,
   playing: bool,
   queue: Vec<SongInQueue>,
   /// Playlist version of the cached queue (`Status::playlist_version`);
@@ -22,6 +26,7 @@ pub(super) async fn run_session(
 ) -> anyhow::Result<()> {
   let mut state = SessionState {
     interrupt: None,
+    restore_attempts: 0,
     playing: false,
     queue: Vec::new(),
     playlist_version: 0,
@@ -136,6 +141,11 @@ async fn refresh_status(
 
 /// After an interrupt preview stops, rebuild the previous queue and state.
 /// Returns true when a restore was performed.
+///
+/// Restores are retried (a bounded number of times) instead of being
+/// abandoned on failure: the saved playlist is the only copy of the
+/// original queue, so it is only deleted once the restore has succeeded.
+/// On persistent failure the playlist is left intact for manual recovery.
 async fn maybe_restore_interrupt(
   client: &Client,
   state: &mut SessionState,
@@ -145,19 +155,53 @@ async fn maybe_restore_interrupt(
   if status.state != PlayState::Stopped {
     return Ok(false);
   }
-  let Some(session) = state.interrupt.take() else {
+  let Some(session) = state.interrupt.as_ref().cloned() else {
     return Ok(false);
   };
   info!("interrupt preview finished; restoring previous queue");
 
   client.command(ClearQueue).await?;
+
   if let Some(playlist) = &session.playlist {
     if let Err(error) = client.command(LoadPlaylist::name(playlist)).await {
-      warn!(%error, playlist = %playlist, "failed to restore saved playlist");
+      state.restore_attempts += 1;
+      warn!(
+        %error, playlist = %playlist, attempts = state.restore_attempts,
+        "failed to restore saved playlist"
+      );
+      if state.restore_attempts < 3 {
+        let _ = events.send(AsyncEvent::Mpd(MpdEvent::Notice(format!(
+          "restore failed ({error}); will retry"
+        ))));
+        // Keep the session armed so a later refresh retries; the saved
+        // playlist (the only copy of the original queue) is untouched.
+        return Ok(false);
+      }
+      let _ = events.send(AsyncEvent::Mpd(MpdEvent::Notice(format!(
+        "could not restore queue from saved playlist `{playlist}`; \
+         it has been left in place so you can load it manually"
+      ))));
+      state.interrupt = None;
+      state.restore_attempts = 0;
+      return Ok(true);
     }
+    // The original queue is now safely back in the live queue, so the
+    // restore is committed: disarm before any later (cosmetic) step so a
+    // failure there cannot re-clear the restored queue on a retry.
+    state.interrupt = None;
+    state.restore_attempts = 0;
     let _ = client.command(DeletePlaylist(playlist.as_str())).await;
+  } else {
+    state.interrupt = None;
+    state.restore_attempts = 0;
+    let _ = client.command(SetSingle(session.single)).await;
+    let _ = events.send(AsyncEvent::Mpd(MpdEvent::Notice(
+      "preview finished; restored previous queue".to_string(),
+    )));
+    return Ok(true);
   }
-  let _ = client.command(SetSingle(session.single)).await;
+
+  client.command(SetSingle(session.single)).await?;
   if let Some(position) = session.position {
     let queue_len = client.command(commands::Queue).await?.len();
     if (position as usize) < queue_len {

--- a/src/open.rs
+++ b/src/open.rs
@@ -138,6 +138,9 @@ pub async fn run_open(args: &OpenArgs, settings: &Settings) -> Result<OpenOutcom
       let target = files.iter().position(|file| file == &path);
       let uris =
         resolve_open_uris(&client, &files, &settings.config.mpd, music_dir.as_deref()).await?;
+      if uris.is_empty() {
+        bail!("no playable audio files under {}", folder.display());
+      }
       client.command(ClearQueue).await?;
       for file_uri in &uris {
         client.command(Add::uri(file_uri)).await?;


### PR DESCRIPTION
- worker: retry interrupt restore without destroying the saved queue; the
  saved playlist (the only copy of the original queue) is only deleted after
  the reload succeeds, and failures are retried a bounded number of times
- open: bail when a folder yields no playable URIs before clearing the queue
  (previously cleared the queue, then failed to play an empty playlist)
- detail: goto_playing keeps the selection when the playing song is filtered
  out instead of falling back to a wrong visible row
