### PR TITLE
fix: harden lyrics parsing, config loading, and library scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ notes. In short: install MPD, create a `mpd.conf` with
 `bind_to_address "127.0.0.1"`, register it as a Windows service
 (`sc.exe create mpd ...`), then run `music-tui`.
 
+### macOS
+
+Apple's built-in Terminal.app implements no image protocol (Kitty, Sixel,
+or iTerm2), so cover art falls back to character art (symbols/ASCII).
+To see real images, use a protocol-capable terminal such as iTerm2,
+WezTerm, or kitty (protocols are auto-detected).
+
 ## Documentation
 
 [doc/index.md](doc/index.md).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,6 +39,9 @@ pub struct Settings {
   /// XDG state dir (library.db, state.toml); logs and cover caches stay
   /// in the cache dir.
   pub state_dir: PathBuf,
+  /// Non-fatal startup notes: config/keymap/theme files that were
+  /// incompatible and got backed up and replaced with defaults.
+  pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -57,6 +60,7 @@ pub async fn load_or_create() -> Result<Settings> {
   let config_dir = app_config_dir();
   let cache_dir = app_cache_dir();
   let state_dir = app_state_dir();
+  let mut warnings: Vec<String> = Vec::new();
 
   fs::create_dir_all(&config_dir)
     .await
@@ -71,27 +75,46 @@ pub async fn load_or_create() -> Result<Settings> {
   migrate_state_files_from_cache(&cache_dir, &state_dir);
 
   let config_path = config_dir.join("config.toml");
-  let mut config = read_or_write_default(&config_path, AppConfig::default()).await?;
+  #[cfg_attr(not(unix), allow(unused_variables))]
+  let (mut config, config_created) =
+    read_or_write_default(&config_path, AppConfig::default(), &mut warnings).await?;
+  // Adopt a freshly generated Unix-socket setup only when the config file
+  // was just created. An existing file — even one still holding the default
+  // `127.0.0.1` host — means the user set it up deliberately, so leave it.
   #[cfg(unix)]
-  let generated_socket = if config.mpd.host == MpdConfig::default().host {
-    mpd_bootstrap::ensure_mpd_config()
-      .await?
-      .map(|bootstrap| bootstrap.socket_path)
+  let (generated_socket, borrow_warnings) = if config_created {
+    match mpd_bootstrap::ensure_mpd_config().await {
+      Ok(Some(bootstrap)) => (Some(bootstrap.socket_path), Vec::new()),
+      Ok(None) => (None, Vec::new()),
+      Err(error) => (
+        None,
+        vec![format!("failed to prepare a default MPD config: {error:#}")],
+      ),
+    }
   } else {
-    None
+    (None, Vec::new())
   };
   #[cfg(not(unix))]
-  let generated_socket: Option<PathBuf> = None;
+  let (generated_socket, borrow_warnings): (Option<PathBuf>, Vec<String>) = (None, Vec::new());
+  warnings.extend(borrow_warnings);
   if let Some(socket) = generated_socket.as_deref()
     && adopt_generated_socket(&mut config, socket)
   {
     let body = app_config_toml(&config)?;
     write_bytes_atomic(&config_path, body.as_bytes()).await?;
   }
-  let keymap =
-    read_or_write_keymap_default(&config_dir.join("keymap.toml"), KeymapConfig::default()).await?;
-  let theme =
-    read_or_write_theme_default(&config_dir.join("theme.toml"), ThemeConfig::default()).await?;
+  let keymap = read_or_write_keymap_default(
+    &config_dir.join("keymap.toml"),
+    KeymapConfig::default(),
+    &mut warnings,
+  )
+  .await?;
+  let theme = read_or_write_theme_default(
+    &config_dir.join("theme.toml"),
+    ThemeConfig::default(),
+    &mut warnings,
+  )
+  .await?;
 
   Ok(Settings {
     config,
@@ -99,6 +122,7 @@ pub async fn load_or_create() -> Result<Settings> {
     theme,
     cache_dir,
     state_dir,
+    warnings,
   })
 }
 
@@ -149,7 +173,11 @@ async fn backup_and_write_theme_default(path: &Path, default: ThemeConfig) -> Re
   write_theme_default(path, default).await
 }
 
-async fn read_or_write_theme_default(path: &Path, default: ThemeConfig) -> Result<ThemeConfig> {
+async fn read_or_write_theme_default(
+  path: &Path,
+  default: ThemeConfig,
+  warnings: &mut Vec<String>,
+) -> Result<ThemeConfig> {
   if !path.exists() {
     return write_theme_default(path, default).await;
   }
@@ -158,7 +186,14 @@ async fn read_or_write_theme_default(path: &Path, default: ThemeConfig) -> Resul
     .with_context(|| format!("failed to read {}", path.display()))?;
   let mut parsed: ThemeConfig = match toml::from_str(&body) {
     Ok(parsed) => parsed,
-    Err(_) => return backup_and_write_theme_default(path, default).await,
+    Err(_) => {
+      let value = backup_and_write_theme_default(path, default).await?;
+      warnings.push(format!(
+        "incompatible theme {} replaced with defaults (backed up as a .bak file)",
+        path.display()
+      ));
+      return Ok(value);
+    }
   };
   parsed.normalize_defaults();
   let normalized = crate::theme::format_theme_toml(&parsed);
@@ -166,7 +201,11 @@ async fn read_or_write_theme_default(path: &Path, default: ThemeConfig) -> Resul
   Ok(parsed)
 }
 
-async fn read_or_write_keymap_default(path: &Path, default: KeymapConfig) -> Result<KeymapConfig> {
+async fn read_or_write_keymap_default(
+  path: &Path,
+  default: KeymapConfig,
+  warnings: &mut Vec<String>,
+) -> Result<KeymapConfig> {
   if !path.exists() {
     return write_keymap_default(path, default).await;
   }
@@ -175,7 +214,14 @@ async fn read_or_write_keymap_default(path: &Path, default: KeymapConfig) -> Res
     .with_context(|| format!("failed to read {}", path.display()))?;
   let mut parsed: KeymapConfig = match toml::from_str(&body) {
     Ok(parsed) => parsed,
-    Err(_) => return backup_and_write_keymap_default(path, default).await,
+    Err(_) => {
+      let value = backup_and_write_keymap_default(path, default).await?;
+      warnings.push(format!(
+        "incompatible keymap {} replaced with defaults (backed up as a .bak file)",
+        path.display()
+      ));
+      return Ok(value);
+    }
   };
   parsed.normalize_defaults();
   let normalized = format_keymap_toml(&parsed);
@@ -183,27 +229,46 @@ async fn read_or_write_keymap_default(path: &Path, default: KeymapConfig) -> Res
   Ok(parsed)
 }
 
-async fn read_or_write_default<T>(path: &Path, default: T) -> Result<T>
+/// Read a config file, filling in defaults. Returns `(value, created)`
+/// where `created` is true when the file did not exist and had to be
+/// written on this run.
+async fn read_or_write_default<T>(
+  path: &Path,
+  default: T,
+  warnings: &mut Vec<String>,
+) -> Result<(T, bool)>
 where
   T: Serialize + for<'de> Deserialize<'de> + Clone + NormalizeConfigDefaults,
 {
   if !path.exists() {
-    return write_default_config(path, default).await;
+    return write_default_config(path, default).await.map(|value| (value, true));
   }
   let body = fs::read_to_string(path)
     .await
     .with_context(|| format!("failed to read {}", path.display()))?;
   let mut parsed: T = match toml::from_str(&body) {
     Ok(parsed) => parsed,
-    Err(_) => return backup_and_write_default_config(path, default).await,
+    Err(_) => {
+      let value = backup_and_write_default_config(path, default).await?;
+      warnings.push(format!(
+        "incompatible config {} replaced with defaults (backed up as a .bak file)",
+        path.display()
+      ));
+      return Ok((value, false));
+    }
   };
   parsed.normalize_defaults();
-  if parsed.validate().is_err() {
-    return backup_and_write_default_config(path, default).await;
+  if let Err(reason) = parsed.validate() {
+    let value = backup_and_write_default_config(path, default).await?;
+    warnings.push(format!(
+      "invalid config {} ({reason}); replaced with defaults (backed up as a .bak file)",
+      path.display()
+    ));
+    return Ok((value, false));
   }
   let normalized = parsed.to_config_toml()?;
   write_back_if_toml_changed(path, &body, &normalized).await?;
-  Ok(parsed)
+  Ok((parsed, false))
 }
 
 fn next_backup_path(path: &Path) -> PathBuf {

--- a/src/library_db/mod.rs
+++ b/src/library_db/mod.rs
@@ -106,13 +106,23 @@ pub fn all_tracks(connection: &Connection) -> Result<Vec<LibraryTrack>> {
   Ok(tracks)
 }
 
-pub fn sync_roots(connection: &Connection, config: &LibraryConfig) -> Result<()> {
+/// Canonical, expanded root paths from the config, in a stable form.
+/// `sync_roots` inserts exactly these into the `roots` table, so the same
+/// list is used to detect roots the user removed from the config.
+pub fn configured_root_paths(config: &LibraryConfig) -> Vec<String> {
+  let mut paths = Vec::new();
   for path in &config.paths {
     let expanded = crate::config::expand_home(path);
     let Ok(canonical) = expanded.canonicalize() else {
       continue;
     };
-    let text = canonical.to_string_lossy().to_string();
+    paths.push(canonical.to_string_lossy().to_string());
+  }
+  paths
+}
+
+pub fn sync_roots(connection: &Connection, config: &LibraryConfig) -> Result<()> {
+  for text in configured_root_paths(config) {
     connection.execute(
       "INSERT OR IGNORE INTO roots (path) VALUES (?1)",
       [text.as_str()],

--- a/src/library_db/scan.rs
+++ b/src/library_db/scan.rs
@@ -25,6 +25,7 @@ pub fn scan_roots(
       .collect::<std::result::Result<Vec<_>, _>>()?
   };
 
+  let transaction = connection.transaction()?;
   let mut scanned = 0usize;
   let mut changed = 0usize;
   for (root_id, root_path) in &roots {
@@ -50,7 +51,7 @@ pub fn scan_roots(
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
       let known: Option<(i64, u64)> = {
-        let mut statement = connection
+        let mut statement = transaction
           .prepare("SELECT id, mtime FROM tracks WHERE root_id = ?1 AND rel_path = ?2")?;
         statement
           .query_row((root_id, rel.as_str()), |row| {
@@ -95,7 +96,7 @@ pub fn scan_roots(
         track.title
       };
       if let Some((id, _)) = known {
-        connection.execute(
+        transaction.execute(
           "UPDATE tracks SET title=?1, artist=?2, album=?3, genre=?4, filename=?5,
              duration_secs=?6, lyrics=?7, mtime=?8 WHERE id=?9",
           rusqlite::params![
@@ -111,7 +112,7 @@ pub fn scan_roots(
           ],
         )?;
       } else {
-        connection.execute(
+        transaction.execute(
           "INSERT INTO tracks (root_id, rel_path, title, artist, album, genre, filename,
              duration_secs, lyrics, mtime) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
           rusqlite::params![
@@ -131,13 +132,18 @@ pub fn scan_roots(
       changed += 1;
     }
   }
+  transaction.commit()?;
   // Drop tracks of roots no longer configured and vanished files.
-  drop_missing(connection, &roots)?;
+  drop_missing(connection, &roots, config)?;
   progress(scanned, changed);
   Ok(())
 }
 
-fn drop_missing(connection: &Connection, roots: &[(i64, String)]) -> Result<()> {
+fn drop_missing(
+  connection: &Connection,
+  roots: &[(i64, String)],
+  config: &LibraryConfig,
+) -> Result<()> {
   for (root_id, root_path) in roots {
     let root = PathBuf::from(root_path);
     let vanished: Vec<i64> = {
@@ -160,19 +166,12 @@ fn drop_missing(connection: &Connection, roots: &[(i64, String)]) -> Result<()> 
       connection.execute("DELETE FROM tracks WHERE id = ?1", [id])?;
     }
   }
-  let configured: Vec<String> = roots.iter().map(|(_, path)| path.clone()).collect();
-  let stale: Vec<i64> = {
-    let mut statement = connection.prepare("SELECT id, path FROM roots")?;
-
-    statement
-      .query_map([], |row| {
-        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-      })?
-      .filter_map(|row| row.ok())
-      .filter(|(_, path)| !configured.contains(path))
-      .map(|(id, _)| id)
-      .collect()
-  };
+  let configured = super::configured_root_paths(config);
+  let stale: Vec<i64> = roots
+    .iter()
+    .filter(|(_, path)| !configured.contains(path))
+    .map(|(id, _)| *id)
+    .collect();
   for id in stale {
     connection.execute("DELETE FROM tracks WHERE root_id = ?1", [id])?;
     connection.execute("DELETE FROM roots WHERE id = ?1", [id])?;

--- a/src/lyrics/parse.rs
+++ b/src/lyrics/parse.rs
@@ -163,9 +163,18 @@ fn parse_lrc_line(line: &str) -> ParsedLine {
   }
 }
 
+/// Upper bound for a sane LRC timestamp (hours). Anything beyond it is a
+/// corrupt/hostile file rather than a real position, so it is rejected
+/// instead of producing an infinite or overflowing duration downstream.
+const MAX_LRC_SECS: f64 = 24.0 * 60.0 * 60.0;
+
 fn parse_lrc_timestamp(stamp: &str) -> Option<f64> {
   let (minutes, seconds) = stamp.split_once(':')?;
   let minutes: f64 = minutes.trim().parse().ok()?;
   let seconds: f64 = seconds.trim().parse().ok()?;
-  Some(minutes * 60.0 + seconds)
+  let value = minutes * 60.0 + seconds;
+  if !value.is_finite() || !(0.0..=MAX_LRC_SECS).contains(&value) {
+    return None;
+  }
+  Some(value)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,18 @@ async fn main() -> Result<()> {
     None => (None, None),
   };
 
-  run_tui(settings, initial_notice, interrupt).await
+  let notice = if settings.warnings.is_empty() {
+    initial_notice
+  } else {
+    let mut joined = settings.warnings.join("\n");
+    if let Some(notice) = initial_notice {
+      joined.push('\n');
+      joined.push_str(&notice);
+    }
+    Some(joined)
+  };
+
+  run_tui(settings, notice, interrupt).await
 }
 
 async fn run_tui(

--- a/src/mpd/worker.rs
+++ b/src/mpd/worker.rs
@@ -249,7 +249,11 @@ async fn run_command(
     }
     MpdCommand::SeekCurrent(seconds) => client
       .command(Seek(SeekMode::Absolute(Duration::from_secs_f64(
-        seconds.max(0.0),
+        if seconds.is_finite() {
+          seconds.clamp(0.0, 24.0 * 60.0 * 60.0)
+        } else {
+          0.0
+        },
       ))))
       .await
       .map(|_| ())

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -20,18 +20,43 @@ pub struct Tui {
 }
 
 impl Tui {
+  /// Create the terminal wrapper, restoring the original terminal modes if
+  /// any initialization step fails. Side effects are applied in order and
+  /// unwound in reverse on error, so a failed `new` never leaves raw mode,
+  /// the alternate screen, or mouse/paste capture engaged.
   pub fn new(protocol_reset: Option<String>) -> Result<Self> {
+    fn reset_modes(stderr: &mut Stderr) {
+      let _ = disable_raw_mode();
+      let _ = execute!(
+        stderr,
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        DisableBracketedPaste
+      );
+    }
     enable_raw_mode()?;
     let mut stderr = io::stderr();
-    execute!(
+    if let Err(error) = execute!(
       stderr,
       EnterAlternateScreen,
       EnableMouseCapture,
       EnableBracketedPaste
-    )?;
+    ) {
+      reset_modes(&mut stderr);
+      return Err(error.into());
+    }
     let backend = CrosstermBackend::new(stderr);
-    let mut terminal = Terminal::new(backend)?;
-    reset_protocol_images(terminal.backend_mut(), protocol_reset.as_deref())?;
+    let mut terminal = match Terminal::new(backend) {
+      Ok(terminal) => terminal,
+      Err(error) => {
+        reset_modes(&mut io::stderr());
+        return Err(error.into());
+      }
+    };
+    if let Err(error) = reset_protocol_images(terminal.backend_mut(), protocol_reset.as_deref()) {
+      reset_modes(&mut io::stderr());
+      return Err(error);
+    }
     Ok(Self {
       terminal,
       protocol_renderer: ProtocolFrameRenderer::default(),


### PR DESCRIPTION
Summary
=======

Fixes a handful of correctness and robustness issues found in a review pass, plus a small README note:

1. **Lyrics timestamp panic** — A corrupt or hostile `.lrc` file could produce `inf`/`NaN` line timestamps, and seeking to such a line ran `Duration::from_secs_f64(inf)`, which panics and kills the MPD worker task.
2. **Silent config resets** — A TOML parse error or failed validation in `config.toml` / `keymap.toml` / `theme.toml` silently backed up and replaced the file with defaults, with no feedback to the user.
3. **Host hijack on first-run socket setup** — The first-run MPD bootstrap redirected `mpd.host` to a Unix socket whenever it matched the default `127.0.0.1`. A user who _explicitly_ configured `127.0.0.1` (e.g. a local TCP daemon over a forwarded port) had their config silently rewritten and connectivity broken.
4. **Stale library roots never pruned** — `drop_missing` compared the `roots` table against itself, so removing a path from `[library]` never deleted its rows; the directory was rescanned forever.
5. **Library scan committed per file** — Each track upsert was its own auto-commit; a large first scan did tens of thousands of commits and an interrupted scan left a half-populated DB.
6. **Terminal state leak on init failure** — `Tui::new` applied raw mode / alternate screen / mouse and paste capture with early-return errors, leaving the terminal unreadable if setup failed partway.
7. **Docs** — Note that macOS Terminal.app has no image protocol, so cover art falls back to symbols/ASCII there.

Changes
-------

| File                                              | Change                                                                                                                                                                                           |
| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `src/lyrics/parse.rs`, `src/mpd/worker.rs`        | Reject non-finite/oversized (≥24h) LRC timestamps at parse time; sanitize the `SeekCurrent` target in the worker as a second line of defense.                                                    |
| `src/config/mod.rs`, `src/main.rs`                | Surface config reset warnings via `Settings.warnings`, shown as a startup notice; consolidate root cleanup metadata; only adopt the generated Unix socket when the config file was just created. |
| `src/library_db/mod.rs`, `src/library_db/scan.rs` | Shared `configured_root_paths()` so stale-root detection matches what `sync_roots` inserts; single transaction around track upserts.                                                             |
| `src/terminal.rs`                                 | Unwind engaged terminal modes (raw mode, alt screen, mouse/paste capture) in reverse if any init step fails.                                                                                     |
| `README.md`                                       | macOS image protocol note.                                                                                                                                                                       |

Testing
-------

* `cargo test --locked` — 62 passed.
* `cargo clippy --locked --all-targets` — no warnings for `music-tui` (the `img-tui` submodule has pre-existing dead-code warnings, out of scope here).

Note: also modifies worker.rs, which PR #3 touches