### PR TITLE
fix(input): 处理终端 Resize 事件以触发界面重绘

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4,6 +4,9 @@ use super::*;
 
 impl App {
   pub fn handle_input(&mut self, event: Event) -> bool {
+    if matches!(event, Event::Resize(_, _)) {
+        return true;
+    }
     if let Event::Paste(value) = event {
       if let Some(prompt) = self.prompt.as_mut() {
         let result =


### PR DESCRIPTION
原因：App::handle_input 未匹配 Event::Resize，导致窗口尺寸变化时未能将 needs_draw 置为 true。

影响：在 niri 等窗口管理器中通过外部快捷键调整窗口大小时，新扩展的区域未触发重绘，出现空白或未渲染错误。

解决：在输入事件处理中捕获 Event::Resize 并返回重绘信号。（AI）