### PR TITLE
fix: cut library scan cycles and clamp config number ranges

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -334,7 +334,16 @@ impl super::AppConfig {
     if self.visualizer.sample_rate == 0 {
       self.visualizer.sample_rate = 44100;
     }
+    if self.visualizer.channels == 0 {
+      self.visualizer.channels = 2;
+    }
+    self.visualizer.channels = self.visualizer.channels.clamp(1, 8);
     self.visualizer.window = self.visualizer.window.clamp(256, 8192).next_power_of_two();
+    for column in &mut self.library.columns {
+      if column.width == 0 {
+        column.width = 1;
+      }
+    }
     self.layout.normalize_defaults();
   }
 
@@ -342,5 +351,36 @@ impl super::AppConfig {
     layout::parse_detail(&self.layout.detail)?;
     layout::parse_tabs(&self.layout)?;
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  fn parse_and_normalize(body: &str) -> crate::config::AppConfig {
+    let mut parsed: crate::config::AppConfig = toml::from_str(body).unwrap();
+    crate::config::AppConfig::normalize_defaults(&mut parsed);
+    parsed
+  }
+
+  #[test]
+  fn visualizer_channels_are_kept_in_a_sane_range() {
+    let zero = parse_and_normalize("[visualizer]\nchannels = 0\n");
+    assert_eq!(zero.visualizer.channels, 2);
+
+    let huge = parse_and_normalize("[visualizer]\nchannels = 99\n");
+    assert_eq!(huge.visualizer.channels, 8);
+
+    let stereo = parse_and_normalize("[visualizer]\nchannels = 2\n");
+    assert_eq!(stereo.visualizer.channels, 2);
+  }
+
+  #[test]
+  fn library_column_width_zero_falls_back_to_one() {
+    let parsed = parse_and_normalize(
+      "[[library.columns]]\nfield = \"title\"\nwidth = 0\n\n\
+       [[library.columns]]\nfield = \"artist\"\nwidth = 4\n",
+    );
+    assert_eq!(parsed.library.columns[0].width, 1);
+    assert_eq!(parsed.library.columns[1].width, 4);
   }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -37,12 +38,28 @@ pub fn is_audio_file(path: &Path) -> bool {
 /// Collect audio files under `root`, sorted by path.
 pub fn collect_audio_files(root: &Path, recursive: bool) -> Result<Vec<PathBuf>> {
   let mut files = Vec::new();
-  visit_audio_files(root, recursive, &mut files)?;
+  let mut visited = HashSet::new();
+  visit_audio_files(root, recursive, &mut visited, &mut files)?;
   files.sort();
   Ok(files)
 }
 
-fn visit_audio_files(dir: &Path, recursive: bool, files: &mut Vec<PathBuf>) -> Result<()> {
+/// Recursively collect audio files under `dir`. Directory cycles are cut by
+/// tracking every resolved directory once: a junction or symlink that points
+/// back towards an ancestor resolves to a path already in the set, so the
+/// scan always terminates even when the tree contains a loop (a Windows
+/// junction into a parent directory otherwise recurses forever). The same
+/// bookkeeping skips directories reachable through two links, collecting
+/// each physical directory's files exactly once.
+fn visit_audio_files(
+  dir: &Path,
+  recursive: bool,
+  visited: &mut HashSet<PathBuf>,
+  files: &mut Vec<PathBuf>,
+) -> Result<()> {
+  if !visited.insert(canonical_or_self(dir)) {
+    return Ok(());
+  }
   let entries = std::fs::read_dir(dir)
     .with_context(|| format!("failed to read directory {}", dir.display()))?;
   for entry in entries {
@@ -56,13 +73,21 @@ fn visit_audio_files(dir: &Path, recursive: bool, files: &mut Vec<PathBuf>) -> R
     let file_type = entry.file_type().context("failed to read file type")?;
     if file_type.is_dir() {
       if recursive && !has_nomedia(&path) {
-        visit_audio_files(&path, recursive, files)?;
+        visit_audio_files(&path, recursive, visited, files)?;
       }
     } else if is_audio_file(&path) {
       files.push(path);
     }
   }
   Ok(())
+}
+
+/// Identity used to detect re-entering the same directory through a junction
+/// or symlink: the fully resolved path when available, otherwise the path as
+/// given. `canonicalize` follows link targets, so a link pointing at an
+/// ancestor produces the ancestor's (already recorded) path.
+fn canonical_or_self(path: &Path) -> PathBuf {
+  std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Android convention: a `.nomedia` marker file inside a directory makes
@@ -401,6 +426,85 @@ mod tests {
     assert!(is_excluded_by_nomedia(&dir, Path::new("a/b/song.mp3")));
     assert!(!is_excluded_by_nomedia(&dir, Path::new("top.mp3")));
     assert!(!is_excluded_by_nomedia(&dir, Path::new("c/other.mp3")));
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn recursive_scan_terminates_on_symlink_cycle() {
+    let dir = std::env::temp_dir().join(format!("music-tui-cycle-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("sub/child")).unwrap();
+    std::fs::write(dir.join("sub/child/song.mp3"), b"").unwrap();
+    std::os::unix::fs::symlink(&dir, dir.join("sub/child/loop")).unwrap();
+
+    let files = collect_audio_files(&dir, true).unwrap();
+    let names: Vec<String> = files
+      .iter()
+      .map(|file| file.file_name().unwrap().to_string_lossy().into_owned())
+      .collect();
+    assert_eq!(names, ["song.mp3"]);
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  #[test]
+  fn visit_skips_already_visited_directories() {
+    let dir = std::env::temp_dir().join(format!("music-tui-visited-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("sub/child")).unwrap();
+    std::fs::write(dir.join("sub/child/song.mp3"), b"").unwrap();
+
+    let mut files = Vec::new();
+    let mut visited = HashSet::new();
+    visited.insert(std::fs::canonicalize(dir.join("sub/child")).unwrap());
+    visit_audio_files(&dir, true, &mut visited, &mut files).unwrap();
+    assert!(files.is_empty(), "already-seen directory must be skipped");
+
+    let mut files = Vec::new();
+    let mut visited = HashSet::new();
+    visit_audio_files(&dir, true, &mut visited, &mut files).unwrap();
+    let names: Vec<String> = files
+      .iter()
+      .map(|file| file.file_name().unwrap().to_string_lossy().into_owned())
+      .collect();
+    assert_eq!(names, ["song.mp3"]);
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn recursive_scan_terminates_on_junction_cycle() {
+    let dir = std::env::temp_dir().join(format!("music-tui-junction-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("sub/child")).unwrap();
+    std::fs::write(dir.join("sub/child/song.mp3"), b"").unwrap();
+    let link = dir.join("sub").join("child").join("loop");
+    let output = std::process::Command::new("cmd")
+      .args([
+        "/C",
+        "mklink",
+        "/J",
+        &link.display().to_string(),
+        &dir.display().to_string(),
+      ])
+      .output()
+      .unwrap();
+    if !output.status.success() {
+      let stderr = String::from_utf8_lossy(&output.stderr);
+      eprintln!("skipping junction test: filesystem does not support junctions ({stderr})");
+      let _ = std::fs::remove_dir_all(&dir);
+      return;
+    }
+
+    let files = collect_audio_files(&dir, true).unwrap();
+    let names: Vec<String> = files
+      .iter()
+      .map(|file| file.file_name().unwrap().to_string_lossy().into_owned())
+      .collect();
+    assert_eq!(names, ["song.mp3"], "junction loop must not recurse or duplicate");
 
     let _ = std::fs::remove_dir_all(&dir);
   }


### PR DESCRIPTION
## What

Two fixes: the library scanner and config normalization.

### 1. Recursive scans terminate on filesystem cycles

`collect_audio_files` passes a canonical-path visited set into `visit_audio_files`. `visit_audio_files` skips any directory already in the set before recursing. A junction (Windows) or symlink (Unix) pointing back at an ancestor no longer loops, and a physical directory reachable through two links is scanned once.

The set resolves each directory with `fs::canonicalize` and falls back to the literal path when canonicalization fails, so existing scan behavior is unchanged where cycles are absent.

### 2. Config values normalize once, at load time

- `visualizer.channels` of `0` becomes `2` and stays capped at `8`. The use site in `src/visualizer/mod.rs:168` previously coerced `0` to `1`; the missing cap let `window × channels × 4` grow toward ~2 GB on extreme configs.
- `library.columns[].width` of `0` becomes `1`. Rendering already clamped this case; config now matches the UI.

## Testing

- `cargo test --locked`: 67 passed.
- `cargo clippy --locked --all-targets`: zero warnings for music-tui.
- Cycle tests are platform-gated: a junction test on Windows (skips gracefully where junctions are unsupported), a symlink test on Unix, and a cross-platform test covering the visited-set guard.
- `cargo fmt --check` not run: the repo uses 2-space style without a `rustfmt.toml`, and this toolchain defaults to 4 spaces, so formatting would add noise. The new code was matched to the house style by hand.
