### PR TITLE
feat(theme): support optional solid background color rendering

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -24,14 +24,31 @@ macro_rules! color_section {
   };
 }
 
-color_section!(BaseSection {
-  foreground => "default",
-  background => "default",
-  border => "bright black",
-  muted => "bright black",
-  accent => "cyan",
-  accent_alt => "magenta",
-});
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BaseSection {
+  pub foreground: String,
+  pub background: String,
+  pub border: String,
+  pub muted: String,
+  pub accent: String,
+  pub accent_alt: String,
+  pub render_background: bool,
+}
+
+impl Default for BaseSection {
+  fn default() -> Self {
+    Self {
+      foreground: "default".to_string(),
+      background: "default".to_string(),
+      border: "bright black".to_string(),
+      muted: "bright black".to_string(),
+      accent: "cyan".to_string(),
+      accent_alt: "magenta".to_string(),
+      render_background: false,
+    }
+  }
+}
 
 color_section!(TabBarSection {
   active => "cyan",
@@ -146,6 +163,25 @@ impl ThemeConfig {
       metadata: MetadataSection::default(),
       visualizer: VisualizerSection::default(),
       which_key: WhichKeySection::default(),
+    }
+  }
+}
+
+impl ThemeConfig {
+  pub fn base_background(&self) -> ratatui::style::Color {
+    if self.base.render_background {
+      self.color(&self.base.background)
+    } else {
+      ratatui::style::Color::Reset
+    }
+  }
+
+  pub fn overlay_background(&self) -> ratatui::style::Color {
+    let base_bg = self.base_background();
+    if base_bg != ratatui::style::Color::Reset {
+      base_bg
+    } else {
+      framework_tui::overlay_background()
     }
   }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -22,7 +22,11 @@ pub(super) fn draw_completion_popup(frame: &mut Frame, app: &App, footer: Rect) 
     frame,
     completion,
     popup,
-    &completion_list_style(theme.color(&theme.which_key.foreground)),
+    &{
+let mut s = completion_list_style(theme.color(&theme.which_key.foreground));
+s.base = s.base.bg(theme.overlay_background());
+s
+},
   );
   Some(popup)
 }
@@ -36,9 +40,9 @@ pub(super) fn draw_help_dialog(
 ) -> (Option<Rect>, Option<(u16, u16)>) {
   let theme = &app.settings.theme;
   // Give the dialog a stable opaque surface even when the theme inherits
-  // the terminal's default background.
-  let background = overlay_background();
-  let base = Style::default()
+// the terminal's default background.
+let background = theme.overlay_background();
+let base = Style::default()
     .fg(theme.color(&theme.base.foreground))
     .bg(background);
   let help_style = KeyHelpDialogStyle {

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -236,15 +236,18 @@ fn library_row(
   // Full-row hover bar: the Row/Cell styles paint the background across
   // the entire row (cells + gaps); spans only set foreground colors so
   // they cannot punch holes in the bar.
-  let row_style = if is_selected {
-    Style::default()
-      .fg(theme.color(&theme.library.selection_foreground))
-      .bg(theme.color(&theme.library.selection_background))
-  } else {
-    Style::default()
-      .fg(theme.color(&theme.base.foreground))
-      .bg(theme.color(&theme.base.background))
-  };
+  let base_bg = theme.base_background();
+let row_style = if is_selected {
+Style::default()
+.fg(theme.color(&theme.library.selection_foreground))
+.bg(theme.color(&theme.library.selection_background))
+} else if base_bg != ratatui::style::Color::Reset {
+Style::default()
+.fg(theme.color(&theme.base.foreground))
+.bg(base_bg)
+} else {
+Style::default().fg(theme.color(&theme.base.foreground))
+};
   let plain_fg = if is_selected {
     theme.color(&theme.library.selection_foreground)
   } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -57,6 +57,10 @@ pub fn draw(
   tx: &mpsc::UnboundedSender<AsyncEvent>,
 ) -> FrameOutput {
   let area = frame.area();
+  let base_bg = app.settings.theme.base_background();
+  if base_bg != ratatui::style::Color::Reset {
+    frame.render_widget(Block::default().style(Style::default().bg(base_bg)), area);
+  }
 
   // Footer height grows with the pending which-key hints (pdf-tui style).
   let hints: Vec<framework_tui::KeyHint> = if app.show_help {


### PR DESCRIPTION
### Summary
Introduces an optional configuration in `theme.toml` to render a custom solid background color across the entire interface, similar to `btop`.

### Motivation
Previously, `[base].background` was only partially applied to unselected library rows, while the rest of the application relied on the terminal's default background (`Color::Reset`). 
### Changes
1. **Config & Theme**:
   - Added `render_background: bool` to `BaseSection` (defaults to `false` for 100% backward compatibility).
   - Encapsulated `base_background()` and `overlay_background()` on `ThemeConfig` to keep background fallback logic clean and centralized.
2. **Rendering**:
   - Render a base background `Block` covering `frame.area()` at the root of `ui::draw` when `render_background` is enabled.
   - Child components naturally inherit the background via Ratatui's `Style::patch`.
   - Adapted `which-key` hints and dialog popups to seamlessly inherit the background without punching transparent holes.

### Testing
- ✅ `cargo check` passes with no warnings or errors.
- ✅ `cargo clippy` passes with no warnings.
- ✅ `cargo build` (debug) completed successfully.
- Manually tested with a custom background color (`#1e1e2e`) and confirmed the entire terminal canvas is filled as expected, including popups and the which-key bar.
- 已知："default" 会被解析为 Color::Reset（即“使用终端默认透明底色”）。即使开关开启了，由于颜色是 Color::Reset，代码检测到没有指定有效颜色，仍然不会绘制背景。所以需要类似以下的两个配置，一个配置色值一个开启渲染，只配置一个则失效。
- 代码由AI提供。

### Real Configuration：
```toml
[base]
foreground = "default"
background = "#1e1e2e"
border = "bright black"
muted = "bright black"
accent = "cyan"
accent_alt = "magenta"
render_background = true
```
### 效果如下图：

<img width="1862" height="1025" alt="ss-20260905-211629" src="https://github.com/user-attachments/assets/bbe6e272-b37b-4992-96ae-2cbedcd65ddc" />