### PR TITLE
fix: strip terminal control characters from rendered text

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -136,8 +136,7 @@ impl App {
           && position < self.queue.len()
         {
           let title = song_title(&self.queue[position].song)
-            .map(str::to_string)
-            .unwrap_or_else(|| self.queue[position].song.url.clone());
+            .unwrap_or_else(|| crate::sanitize::sanitize_text(&self.queue[position].song.url));
           self.mpdc(MpdCommand::DeleteAt(position));
           self.set_message(format!("deleted: {title}"));
         }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -346,10 +346,10 @@ impl App {
     let mut written = 0;
     for song in &self.queue {
       let song = &song.song;
-      let artist = song_artist(song).map(str::to_string).unwrap_or_default();
+      let artist = song_artist(song).unwrap_or_default();
       let label = match (artist.is_empty(), song_title(song)) {
         (false, Some(title)) => format!("{artist} - {title}"),
-        (true, Some(title)) => title.to_string(),
+        (true, Some(title)) => title,
         _ => song.url.clone(),
       };
       let seconds = song

--- a/src/app/detail.rs
+++ b/src/app/detail.rs
@@ -70,9 +70,7 @@ impl App {
       self.set_message("local song path is unavailable");
       return true;
     };
-    let title = song_title(&song.song)
-      .map(str::to_string)
-      .unwrap_or_else(|| url.clone());
+    let title = song_title(&song.song).unwrap_or_else(|| crate::sanitize::sanitize_text(&url));
     self.open_detail_view(url, path, title);
     true
   }

--- a/src/app/labels.rs
+++ b/src/app/labels.rs
@@ -1,33 +1,35 @@
 //! Queue label helpers: title/artist straight from the tags MPD reports.
 //!
-//! No corruption heuristics here: values are shown as reported. When a
-//! file's tags are wrong (e.g. mixed-encoding duplicates), fix them in the
-//! metadata editor — the write hits every tag block and music-tui then
-//! asks MPD to update its database entry for the file.
+//! No corruption heuristics here: values are shown as reported (control
+//! characters stripped for terminal safety). When a file's tags are wrong
+//! (e.g. mixed-encoding duplicates), fix them in the metadata editor — the
+//! write hits every tag block and music-tui then asks MPD to update its
+//! database entry for the file.
 
 use super::*;
+use crate::sanitize::sanitize_text;
 use mpd_client::tag::Tag;
 
-/// The song's title (first reported value, trimmed).
-pub(crate) fn song_title(song: &Song) -> Option<&str> {
+/// The song's title (first reported value, trimmed and sanitized).
+pub(crate) fn song_title(song: &Song) -> Option<String> {
   tag_value(song, Tag::Title)
 }
 
-/// The song's artist (first reported value, trimmed).
-pub(crate) fn song_artist(song: &Song) -> Option<&str> {
+/// The song's artist (first reported value, trimmed and sanitized).
+pub(crate) fn song_artist(song: &Song) -> Option<String> {
   tag_value(song, Tag::Artist)
 }
 
-/// The song's album (first reported value, trimmed).
-pub(crate) fn song_album(song: &Song) -> Option<&str> {
+/// The song's album (first reported value, trimmed and sanitized).
+pub(crate) fn song_album(song: &Song) -> Option<String> {
   tag_value(song, Tag::Album)
 }
 
-fn tag_value(song: &Song, tag: Tag) -> Option<&str> {
+fn tag_value(song: &Song, tag: Tag) -> Option<String> {
   song
     .tags
     .get(&tag)
     .and_then(|values| values.first())
-    .map(|value| value.trim())
+    .map(|value| sanitize_text(value.trim()))
     .filter(|value| !value.is_empty())
 }

--- a/src/app/loading.rs
+++ b/src/app/loading.rs
@@ -75,12 +75,8 @@ impl App {
   pub(crate) fn current_song_tags(&self) -> (Option<String>, Option<String>) {
     let song = self.current_song();
     (
-      song.and_then(|song| song_artist(&song.song).map(str::to_string)),
-      song.map(|song| {
-        song_title(&song.song)
-          .map(str::to_string)
-          .unwrap_or_else(|| song.song.url.clone())
-      }),
+      song.and_then(|song| song_artist(&song.song)),
+      song.map(|song| song_title(&song.song).unwrap_or_else(|| song.song.url.clone())),
     )
   }
 
@@ -149,10 +145,8 @@ impl App {
       self.hover = None;
       return;
     };
-    let title = song_title(&song.song)
-      .map(str::to_string)
-      .unwrap_or_else(|| url.clone());
-    let artist = song_artist(&song.song).map(str::to_string);
+    let title = song_title(&song.song).unwrap_or_else(|| crate::sanitize::sanitize_text(&url));
+    let artist = song_artist(&song.song);
     let lyric_title = title.clone();
     self.hover = Some(SongView::new(url.clone(), path.clone(), title));
     self.spawn_song_view_loads(url, &path, artist, &lyric_title, true);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -307,7 +307,8 @@ impl App {
   }
 
   pub fn set_message(&mut self, message: impl Into<String>) {
-    self.message = Some((message.into(), Instant::now()));
+    let message = crate::sanitize::sanitize_text(&message.into());
+    self.message = Some((message, Instant::now()));
   }
 
   pub fn message_text(&self) -> Option<&str> {

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -13,7 +13,7 @@ impl App {
       }
       MpdEvent::ConnectionLost(reason) => {
         self.connected = None;
-        self.connection_error = Some(reason);
+        self.connection_error = Some(crate::sanitize::sanitize_text(&reason));
         self.status = None;
         true
       }
@@ -79,9 +79,9 @@ impl App {
     // Every space-separated term must match somewhere (AND); field text
     // matches with spaces ignored ("Love Story" ~ "lovestory").
     terms.iter().all(|term| {
-      song_title(song).is_some_and(|value| StrippedText::new(value).matches(term))
-        || song_artist(song).is_some_and(|value| StrippedText::new(value).matches(term))
-        || song_album(song).is_some_and(|value| StrippedText::new(value).matches(term))
+      song_title(song).is_some_and(|value| StrippedText::new(&value).matches(term))
+        || song_artist(song).is_some_and(|value| StrippedText::new(&value).matches(term))
+        || song_album(song).is_some_and(|value| StrippedText::new(&value).matches(term))
         || StrippedText::new(&song.url).matches(term)
     })
   }

--- a/src/library_db/scan.rs
+++ b/src/library_db/scan.rs
@@ -226,22 +226,24 @@ fn read_track(path: &Path) -> Option<LibraryTrack> {
   let track = LibraryTrack {
     id: 0,
     path: path.to_path_buf(),
-    title: tag.title().unwrap_or_default().trim().to_string(),
+    title: crate::sanitize::sanitize_text(tag.title().unwrap_or_default().trim()),
     artist: tag
       .artist()
-      .map(|artist| artist.to_string())
+      .map(|artist| crate::sanitize::sanitize_text(&artist))
       .unwrap_or_default(),
-    album: tag.album().unwrap_or_default().trim().to_string(),
-    genre: tag.genre().unwrap_or_default().trim().to_string(),
+    album: crate::sanitize::sanitize_text(tag.album().unwrap_or_default().trim()),
+    genre: crate::sanitize::sanitize_text(tag.genre().unwrap_or_default().trim()),
     filename: path
       .file_stem()
       .map(|stem| stem.to_string_lossy().to_string())
       .unwrap_or_default(),
     duration_secs: properties.duration().as_secs_f64(),
-    lyrics: tag
-      .get_string(&lofty::tag::ItemKey::Lyrics)
-      .unwrap_or_default()
-      .to_lowercase(),
+    lyrics: crate::sanitize::sanitize_text(
+      &tag
+        .get_string(&lofty::tag::ItemKey::Lyrics)
+        .unwrap_or_default()
+        .to_lowercase(),
+    ),
     mtime: 0,
   };
   Some(track)
@@ -250,9 +252,10 @@ fn read_track(path: &Path) -> Option<LibraryTrack> {
 /// Sidecar lyrics as a lowercase blob for filtering; embedded lyrics are
 /// already read by `read_track` (one lofty probe per file).
 fn read_sidecar_lyrics(path: &Path) -> String {
-  std::fs::read_to_string(path.with_extension("lrc"))
+  let lyrics = std::fs::read_to_string(path.with_extension("lrc"))
     .unwrap_or_default()
-    .to_lowercase()
+    .to_lowercase();
+  crate::sanitize::sanitize_text(&lyrics)
 }
 
 #[cfg(test)]

--- a/src/lyrics/parse.rs
+++ b/src/lyrics/parse.rs
@@ -6,9 +6,9 @@ pub fn parse(body: &str) -> Result<Lyrics, String> {
   let mut timed: Vec<SyncedLine> = Vec::new();
   let mut plain: Vec<String> = Vec::new();
 
-  for line in body.lines() {
-    let line = line.trim_end_matches('\r');
-    match parse_lrc_line(line) {
+  for raw_line in body.lines() {
+    let line = crate::sanitize::sanitize_text(raw_line.trim_end_matches('\r'));
+    match parse_lrc_line(&line) {
       ParsedLine::Timed { times, text, words } => {
         if times.is_empty() {
           plain.push(line.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod mpd;
 mod open;
 mod playlist;
 mod render;
+mod sanitize;
 mod state;
 mod strip;
 mod terminal;

--- a/src/mpd/worker.rs
+++ b/src/mpd/worker.rs
@@ -171,15 +171,17 @@ async fn maybe_restore_interrupt(
       );
       if state.restore_attempts < 3 {
         let _ = events.send(AsyncEvent::Mpd(MpdEvent::Notice(format!(
-          "restore failed ({error}); will retry"
+          "restore failed ({}); will retry",
+          crate::sanitize::sanitize_text(&error.to_string())
         ))));
         // Keep the session armed so a later refresh retries; the saved
         // playlist (the only copy of the original queue) is untouched.
         return Ok(false);
       }
       let _ = events.send(AsyncEvent::Mpd(MpdEvent::Notice(format!(
-        "could not restore queue from saved playlist `{playlist}`; \
-         it has been left in place so you can load it manually"
+        "could not restore queue from saved playlist `{}`; \
+         it has been left in place so you can load it manually",
+        crate::sanitize::sanitize_text(playlist)
       ))));
       state.interrupt = None;
       state.restore_attempts = 0;

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,37 @@
+//! Terminal-output sanitation.
+//!
+//! Untrusted text — MPD tags, URLs, PLS/LRC bodies, server error strings —
+//! can carry control characters (ESC, CSI, C1 ranges) that a terminal would
+//! interpret as input instead of rendering. Strip every control character
+//! so all text that reaches ratatui is display-only.
+
+pub(crate) fn sanitize_text(text: &str) -> String {
+  text
+    .chars()
+    .filter(|ch| !ch.is_control() && *ch != '\u{7f}')
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn keeps_printable_text() {
+    assert_eq!(sanitize_text("ABC cde 123"), "ABC cde 123");
+    assert_eq!(sanitize_text("夜的第七章"), "夜的第七章");
+    assert_eq!(sanitize_text("a_b-c.d"), "a_b-c.d");
+  }
+
+  #[test]
+  fn strips_escape_sequences() {
+    assert_eq!(sanitize_text("hello \u{1b}[31mred"), "hello [31mred");
+    assert_eq!(sanitize_text("\u{1b}]0;x\u{7}"), "]0;x");
+    assert_eq!(sanitize_text("\u{9b}1 @"), "1 @");
+  }
+
+  #[test]
+  fn strips_tabs_newlines_and_del() {
+    assert_eq!(sanitize_text("a\tb\nc\u{7f}d"), "abcd");
+  }
+}

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -62,12 +62,9 @@ pub(super) fn draw_footer(
     }
   }
   if let Some(song) = app.current_song() {
-    let title = song_title(&song.song)
-      .map(str::to_string)
-      .unwrap_or_else(|| song.song.url.clone());
-    let artist = song_artist(&song.song)
-      .map(str::to_string)
-      .unwrap_or_default();
+    let title =
+      song_title(&song.song).unwrap_or_else(|| crate::sanitize::sanitize_text(&song.song.url));
+    let artist = song_artist(&song.song).unwrap_or_default();
     let label = if artist.is_empty() {
       title
     } else {

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -42,6 +42,7 @@ pub(super) fn draw_metadata_pane(frame: &mut Frame, app: &mut App, area: Rect, s
 
 pub(super) fn metadata_line(app: &App, name: &str, value: &str) -> Line<'static> {
   let theme = &app.settings.theme;
+  let value = crate::sanitize::sanitize_text(value);
   let mut label = format!("{name}:");
   let pad = 16usize.saturating_sub(label.chars().count());
   label.push_str(&" ".repeat(pad));
@@ -53,7 +54,7 @@ pub(super) fn metadata_line(app: &App, name: &str, value: &str) -> Line<'static>
         .add_modifier(Modifier::BOLD),
     ),
     Span::styled(
-      value.to_string(),
+      value,
       Style::default().fg(theme.color(&theme.base.foreground)),
     ),
   ])

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,7 +1,12 @@
 //! Queue pane rendering.
 
 use super::*;
+use crate::sanitize::sanitize_text;
 use crate::strip::StrippedText;
+
+fn sanitize_url(url: &str) -> String {
+  sanitize_text(url)
+}
 
 pub(super) fn draw_queue_pane(frame: &mut Frame, app: &mut App, area: Rect) {
   let theme = &app.settings.theme;
@@ -104,12 +109,8 @@ fn queue_line(
   playing: Option<usize>,
 ) -> Line<'static> {
   let theme = &app.settings.theme;
-  let title = song_title(&song.song)
-    .map(str::to_string)
-    .unwrap_or_else(|| song.song.url.clone());
-  let artist = song_artist(&song.song)
-    .map(str::to_string)
-    .unwrap_or_default();
+  let title = song_title(&song.song).unwrap_or_else(|| sanitize_url(&song.song.url));
+  let artist = song_artist(&song.song).unwrap_or_default();
   let marker = if playing == Some(index) {
     match app.status.as_ref().map(|status| status.state) {
       Some(PlayState::Playing) => {
@@ -176,7 +177,7 @@ fn queue_line(
     // Terms that only match the album or the URL still need a visible
     // highlight, so append those fields when they contain a match.
     if let Some(album) = song_album(&song.song) {
-      let album_text = StrippedText::new(album);
+      let album_text = StrippedText::new(&album);
       let ranges: Vec<(usize, usize)> = terms
         .iter()
         .flat_map(|term| album_text.find_all(term))
@@ -184,11 +185,12 @@ fn queue_line(
       if !ranges.is_empty() {
         spans.push(Span::styled(" · ", muted));
         spans.extend(highlighted_ranges_spans(
-          album, album, 0, ranges, muted, highlight,
+          &album, &album, 0, ranges, muted, highlight,
         ));
       }
     }
-    let url_text = StrippedText::new(&song.song.url);
+    let url = sanitize_url(&song.song.url);
+    let url_text = StrippedText::new(&url);
     let url_ranges: Vec<(usize, usize)> = terms
       .iter()
       .flat_map(|term| url_text.find_all(term))
@@ -196,12 +198,7 @@ fn queue_line(
     if !url_ranges.is_empty() {
       spans.push(Span::styled(" ⟨", muted));
       spans.extend(highlighted_ranges_spans(
-        &song.song.url,
-        &song.song.url,
-        0,
-        url_ranges,
-        muted,
-        highlight,
+        &url, &url, 0, url_ranges, muted, highlight,
       ));
       spans.push(Span::styled("⟩", muted));
     }


### PR DESCRIPTION
Untrusted text — MPD tags and URLs, PLS/LRC bodies, server error strings —
could carry ESC/CSI/C1 control characters that a terminal would interpret
as input instead of rendering. Strip every control character at the source
so all text that reaches the UI is display-only.

Sanitization points (new src/sanitize.rs, used at every entry):
- MPD tag accessors (title/artist/album) now return owned, sanitized
  Strings; queue, footer, detail, hover and filter paths all consume them.
- Library DB fields (title/artist/album/genre/lyrics, sidecar lyrics)
  from lofty tag reads.
- LRC lines (timed, word-timed and plain fallback).
- Footer/notice/error strings: set_message, connection errors, worker
  restore notices, metadata pane values, queue/fallback URLs.

Tests: 70 pass (3 new sanitizer cases: ESC/OSC sequences, C1 controls,
tabs/newlines/DEL). cargo clippy --locked --all-targets clean; music-tui
files format-clean under the repo's pinned 2-space rustfmt (the only
remaining format diffs live in the isolated framework-tui submodule).
