### PR TITLE
fix: guard panic paths in playlist, volume, visualizer, layout, columns

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -215,14 +215,8 @@ impl App {
       "prev" => self.mpdc(MpdCommand::Previous),
       "volume" | "vol" => match args.first() {
         Some(value) => {
-          if let Some(delta) = value.strip_prefix(['+', '-']) {
-            let magnitude: i16 = delta.parse().unwrap_or(0);
-            let signed = if value.starts_with('-') {
-              -magnitude
-            } else {
-              magnitude
-            };
-            self.mpdc(MpdCommand::NudgeVolume(signed));
+          if let Some(nudge) = parse_volume_delta(value) {
+            self.mpdc(MpdCommand::NudgeVolume(nudge));
           } else if let Ok(volume) = value.parse::<u8>() {
             self.mpdc(MpdCommand::SetVolume(volume.min(100)));
           } else {
@@ -372,5 +366,45 @@ impl App {
       Ok(()) => self.set_message(format!("saved {written} song(s) to {}", target.display())),
       Err(error) => self.set_message(format!("save failed: {error}")),
     }
+  }
+}
+
+/// Parse a `+N`/`-N` relative volume for the `:volume` command. The raw
+/// magnitude is parsed as i32 so a `--32768`-style value can no longer
+/// overflow when negated; deltas beyond the MPD 0..100 range are clamped
+/// (the worker also clamps the resulting level, so the effect is identical).
+fn parse_volume_delta(arg: &str) -> Option<i16> {
+  let delta = arg.strip_prefix(['+', '-'])?;
+  let magnitude: i32 = delta.parse().ok()?;
+  let signed = if arg.starts_with('-') {
+    magnitude.saturating_neg()
+  } else {
+    magnitude
+  };
+  Some(signed.clamp(-100, 100) as i16)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn volume_delta_parses_signed_values() {
+    assert_eq!(parse_volume_delta("50"), None);
+    assert_eq!(parse_volume_delta("+50"), Some(50));
+    assert_eq!(parse_volume_delta("-50"), Some(-50));
+  }
+
+  #[test]
+  fn volume_delta_clamps_and_never_overflows() {
+    assert_eq!(parse_volume_delta("--32768"), Some(100));
+    assert_eq!(parse_volume_delta("-200"), Some(-100));
+    assert_eq!(parse_volume_delta("+200"), Some(100));
+  }
+
+  #[test]
+  fn volume_delta_rejects_garbage() {
+    assert_eq!(parse_volume_delta("+abc"), None);
+    assert_eq!(parse_volume_delta("--99999999999999999999"), None);
   }
 }

--- a/src/layout/parser.rs
+++ b/src/layout/parser.rs
@@ -2,17 +2,22 @@
 
 use super::{PaneKind, PaneLayout, PaneSource, SplitDir};
 
+/// Deepest allowed nested split. Recursion is bounded so a pathological
+/// config fails cleanly instead of exhausting the stack; real layouts are
+/// a handful of levels.
+const MAX_LAYOUT_DEPTH: usize = 64;
+
 pub(super) fn parse(spec: &str) -> Result<PaneLayout, String> {
   let mut tokens = Tokenizer::new(spec);
-  let node = parse_node(&mut tokens)?;
+  let node = parse_node(&mut tokens, 0)?;
   tokens.expect_end()?;
   Ok(node)
 }
 
-fn parse_node(tokens: &mut Tokenizer) -> Result<PaneLayout, String> {
+fn parse_node(tokens: &mut Tokenizer, depth: usize) -> Result<PaneLayout, String> {
   tokens.skip_whitespace();
   match tokens.peek() {
-    Some('H') | Some('V') => parse_split(tokens),
+    Some('H') | Some('V') => parse_split(tokens, depth),
     Some(_) => {
       let word = tokens.read_word();
       let kind = PaneKind::parse(&word).ok_or_else(|| {
@@ -44,7 +49,10 @@ fn parse_node(tokens: &mut Tokenizer) -> Result<PaneLayout, String> {
   }
 }
 
-fn parse_split(tokens: &mut Tokenizer) -> Result<PaneLayout, String> {
+fn parse_split(tokens: &mut Tokenizer, depth: usize) -> Result<PaneLayout, String> {
+  if depth >= MAX_LAYOUT_DEPTH {
+    return Err("layout nested too deeply".to_string());
+  }
   let dir = match tokens.next() {
     Some('H') => SplitDir::Horizontal,
     Some('V') => SplitDir::Vertical,
@@ -54,9 +62,9 @@ fn parse_split(tokens: &mut Tokenizer) -> Result<PaneLayout, String> {
   tokens.expect_char('(')?;
   let ratio = parse_ratio(tokens)?;
   tokens.expect_char(',')?;
-  let first = parse_node(tokens)?;
+  let first = parse_node(tokens, depth + 1)?;
   tokens.expect_char(',')?;
-  let second = parse_node(tokens)?;
+  let second = parse_node(tokens, depth + 1)?;
   tokens.expect_char(')')?;
   Ok(PaneLayout::Split {
     dir,
@@ -74,6 +82,11 @@ fn parse_ratio(tokens: &mut Tokenizer) -> Result<(u32, u32), String> {
   if first == 0 || second == 0 {
     return Err(format!("ratio {first}:{second} must be positive"));
   }
+  // Rendering sums the two weights into a ratio constraint; reject sums
+  // that overflow u32 up front instead of panicking later.
+  first
+    .checked_add(second)
+    .ok_or_else(|| format!("ratio {first}:{second} is too large"))?;
   Ok((first, second))
 }
 
@@ -139,5 +152,28 @@ impl Tokenizer {
     digits
       .parse()
       .map_err(|_| format!("expected a number, found {digits:?}"))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ratio_addition_cannot_overflow() {
+    assert!(parse("4294967295:1, queue, lyrics").is_err());
+    assert!(parse("1:4294967295, queue, lyrics").is_err());
+  }
+
+  #[test]
+  fn excessive_nesting_is_rejected() {
+    let spec = format!("{}queue{})", "H(1:1,".repeat(80), ")".repeat(80));
+    assert!(parse(&spec).is_err());
+  }
+
+  #[test]
+  fn split_trees_still_parse() {
+    assert!(parse("H(2:1, queue, cover)").is_ok());
+    assert!(parse("V(1:1, H(2:1, cover, metadata), lyrics)").is_ok());
   }
 }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -43,14 +43,19 @@ pub fn parse_playlist(path: &Path) -> Result<Vec<PathBuf>, String> {
   Ok(entries)
 }
 
-/// `FileN=value` entries of a PLS file, in file order.
+/// `FileN=value` entries of a PLS file, in file order. Byte slicing is done
+/// via `get(..4)`/`get(4..)` so a multi-byte UTF-8 key prefix can never hit
+/// a mid-character boundary and panic the reader.
 fn pls_entry(line: &str) -> Option<&str> {
   let (key, value) = line.split_once('=')?;
   let key = key.trim();
-  if key.len() >= 5
-    && key[..4].eq_ignore_ascii_case("file")
-    && key[4..].chars().all(|c| c.is_ascii_digit())
-  {
+  let is_file_entry = match (key.get(..4), key.get(4..)) {
+    (Some(prefix), Some(track)) => {
+      prefix.eq_ignore_ascii_case("file") && track.chars().all(|c| c.is_ascii_digit())
+    }
+    _ => false,
+  };
+  if is_file_entry {
     let value = value.trim();
     (!value.is_empty()).then_some(value)
   } else {
@@ -176,6 +181,14 @@ mod tests {
     assert_eq!(entries[1], absolute);
     let _ = std::fs::remove_file(&path);
     cleanup_tmp();
+  }
+
+  #[test]
+  fn pls_entry_ignores_multibyte_key_prefixes() {
+    // 'File' cut at a non-char boundary used to panic the byte slicing.
+    assert!(pls_entry("ñññx=1.mp3").is_none());
+    assert_eq!(pls_entry("File12=one.ogg"), Some("one.ogg"));
+    assert!(pls_entry("filex=one.ogg").is_none());
   }
 
   #[test]

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -68,8 +68,8 @@ fn draw_detail_layout(frame: &mut Frame, ctx: &mut DetailCtx<'_>, area: Rect, la
       second,
     } => {
       let constraints = [
-        Constraint::Ratio(ratio.0, ratio.0 + ratio.1),
-        Constraint::Ratio(ratio.1, ratio.0 + ratio.1),
+        Constraint::Ratio(ratio.0, ratio.0.saturating_add(ratio.1)),
+        Constraint::Ratio(ratio.1, ratio.0.saturating_add(ratio.1)),
       ];
       let areas: [Rect; 2] = match dir {
         SplitDir::Horizontal => Layout::horizontal(constraints).areas(area),

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -189,15 +189,21 @@ fn display_columns(app: &App) -> Vec<DisplayColumn> {
 
 /// Divide `available` cells between columns by weight. The leading
 /// playing-marker column (2 cells) and the single gap between each
-/// column are reserved first.
+/// column are reserved first. Widths are computed in u64: a single large
+/// user-configured weight times a full-width budget would overflow u32.
 fn column_widths(columns: &[DisplayColumn], available: u16) -> Vec<u16> {
-  let total: u32 = columns.iter().map(|column| column.weight).sum();
+  let total: u64 = columns.iter().map(|column| u64::from(column.weight)).sum();
   let count = columns.len() as u16;
   let gaps = count; // one gap after the marker and between each column
   let budget = available.saturating_sub(2 + gaps).max(count);
   let mut widths: Vec<u16> = columns
     .iter()
-    .map(|column| ((u32::from(budget) * column.weight / total.max(1)) as u16).clamp(1, budget))
+    .map(|column| {
+      let width = u64::from(budget) * u64::from(column.weight) / total.max(1);
+      // width <= budget always (total >= each weight), so the try_from
+      // never fails; the fallback keeps the function total regardless.
+      (u16::try_from(width.min(u64::from(budget))).unwrap_or(budget)).clamp(1, budget)
+    })
     .collect();
   // Hand out the remainder left to right.
   let used: u16 = widths.iter().sum();
@@ -327,4 +333,44 @@ fn library_row(
     cells.push(cell);
   }
   Row::new(cells).height(1).style(row_style)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn column(weight: u32) -> DisplayColumn {
+    DisplayColumn {
+      weight,
+      kind: ColumnKind::Field(TrackField::Title),
+    }
+  }
+
+  #[test]
+  fn column_widths_survive_huge_weights() {
+    // budget * weight used to multiply in u32 and overflow with a
+    // maximum-weight column on a full-width pane.
+    let columns = vec![column(u32::MAX), column(u32::MAX)];
+    let widths = column_widths(&columns, 100);
+    assert_eq!(widths.len(), 2);
+    let used: u16 = widths.iter().sum();
+    assert_eq!(used, 100 - 2 - 2); // marker + inter-column gaps
+    assert!(widths.iter().all(|width| *width >= 1));
+  }
+
+  #[test]
+  fn weighted_shares_plus_remainder_fit_budget() {
+    let columns = vec![column(2), column(1)];
+    let widths = column_widths(&columns, 20);
+    assert_eq!(widths[0], 11);
+    assert_eq!(widths[1], 5);
+    assert_eq!(widths.iter().sum::<u16>(), 20 - 2 - 2);
+  }
+
+  #[test]
+  fn zero_weight_columns_still_get_minimum_width() {
+    let columns = vec![column(0), column(1)];
+    let widths = column_widths(&columns, 20);
+    assert!(widths.iter().all(|width| *width >= 1));
+  }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -230,8 +230,8 @@ fn draw_layout(
       second,
     } => {
       let constraints = [
-        Constraint::Ratio(ratio.0, ratio.0 + ratio.1),
-        Constraint::Ratio(ratio.1, ratio.0 + ratio.1),
+        Constraint::Ratio(ratio.0, ratio.0.saturating_add(ratio.1)),
+        Constraint::Ratio(ratio.1, ratio.0.saturating_add(ratio.1)),
       ];
       let areas: [Rect; 2] = match dir {
         SplitDir::Horizontal => Layout::horizontal(constraints).areas(area),

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -110,9 +110,15 @@ fn band_bin_ranges(edges: &[f32], window: usize, sample_rate: u32) -> Vec<(usize
   edges
     .windows(2)
     .map(|pair| {
-      let start_bin = ((pair[0] / nyquist) * bins as f32).floor().max(1.0) as usize;
-      let end_bin =
-        (((pair[1] / nyquist) * bins as f32).ceil() as usize).clamp(start_bin + 1, bins);
+      let start_bin = ((pair[0] / nyquist) * bins as f32)
+        .floor()
+        .max(1.0)
+        .min(bins as f32) as usize;
+      // Total even when the Nyquist limit collapses to min_freq: a plain
+      // `.clamp(start_bin + 1, bins)` panics once start_bin hits `bins`.
+      let end_bin = (((pair[1] / nyquist) * bins as f32).ceil() as usize)
+        .max(start_bin + 1)
+        .min(bins);
       (start_bin, end_bin)
     })
     .fold(Vec::new(), |mut ranges, range| {
@@ -174,8 +180,10 @@ fn run(
 
   // A zero `sample_rate` (an explicit-but-invalid config: the schema
   // default is 44100) would make nyquist/hz-per-bin drop to zero below and
-  // panic the thread, so clamp before any frequency math.
-  let sample_rate = config.sample_rate.max(1);
+  // panic the thread. Clamp to 80 (= 2 * min_freq) so the Nyquist limit
+  // never falls below the lowest band edge and band-to-bin mapping stays
+  // valid; the schema re-clamps as well (see normalize_defaults).
+  let sample_rate = config.sample_rate.max(80);
   let mut columns_now = config.bars.max(1);
   let hz_per_bin = sample_rate as f32 / window as f32;
   let min_freq = 40.0f32;
@@ -433,6 +441,32 @@ mod tests {
       "hint 8 -> {} edges",
       edges.len()
     );
+  }
+
+  #[test]
+  fn band_ranges_stay_valid_when_nyquist_below_min_freq() {
+    // A sample_rate below 2 * min_freq (40 Hz) puts the Nyquist limit under
+    // the lowest band edge; the mapping must keep every range start <= end
+    // (it used to invert and panic the spectrum slice).
+    let window = 512;
+    let ranges = band_bin_ranges(&[40.0, 20.0], window, 40);
+    assert!(!ranges.is_empty());
+    for &(start, end) in &ranges {
+      assert!(start <= end, "band range must not invert: ({start}, {end})");
+    }
+  }
+
+  #[test]
+  fn band_ranges_stay_valid_at_minimum_sample_rate() {
+    // run() clamps sample_rate to 80 (= 2 * min_freq), where the final
+    // edge equals Nyquist: the degenerate [min_freq, max_freq] pair must
+    // not panic the range clamp.
+    let window = 256;
+    let ranges = band_bin_ranges(&[40.0, 40.0], window, 80);
+    assert!(!ranges.is_empty());
+    for &(start, end) in &ranges {
+      assert!(start <= end, "band range must not invert: ({start}, {end})");
+    }
   }
 
   #[test]

--- a/src/visualizer/render.rs
+++ b/src/visualizer/render.rs
@@ -164,7 +164,7 @@ pub(crate) fn build_band_lines(
       let remainder = value * height % 100; // fraction of the tip row
       let (ch, lit) = if from_bottom < full {
         ('█', true)
-      } else if from_bottom == full && value > 0 {
+      } else if from_bottom == full && value > 0 && remainder > 0 {
         // Ceil the tip fraction into a glyph bucket (1..=7) so the top
         // glyph is reachable; a plain integer division capped the highest
         // bucket (index 7 -> '▇') off and omitted every fractional tip.
@@ -294,6 +294,22 @@ mod tests {
     let lines = build_band_lines(1, 101, &[99], &colors);
     let tip = &lines[1];
     assert!(tip.spans[0].content.contains('▇'), "tip row: {tip:?}");
+  }
+
+  #[test]
+  fn exact_division_draws_no_spurious_tip() {
+    // 50% of a 2-row pane is exactly one full row (remainder zero): the
+    // leftover '▁' tip used to add a stray cell that pushed the bar past
+    // its exact height.
+    let colors = VisualizerColors {
+      low: Color::Green,
+      mid: Color::Yellow,
+      high: Color::Red,
+    };
+    let lines = build_band_lines(1, 2, &[50], &colors);
+    assert_eq!(lines.len(), 2);
+    assert!(lines[1].spans[0].content.contains('█'));
+    assert_eq!(lines[0].spans[0].content, " ");
   }
 
   #[test]


### PR DESCRIPTION
Six hardening fixes (batch A), each with a regression test:

- src/playlist.rs: pls_entry matched FileN= by byte-slicing key[..4], which
  panicked on a multi-byte UTF-8 key prefix starting with "file"; switch to
  get(..4)/get(4..) and reject the 4-byte "file" bare key (empty track).
- src/app/commands.rs: ":volume --32768" negated an i16::MIN and overflowed;
  parse the magnitude as i32, saturating_neg, clamp deltas to +/-100 (the
  worker clamps the final level anyway). "+abc" now reports "invalid volume"
  instead of silently nudging by zero.
- src/visualizer/mod.rs: clamp sample_rate to 80 (= 2 * min_freq) so Nyquist
  never drops below the lowest band edge, and make band_bin_ranges total:
  a degenerate [min_freq, max_freq] edge pair hit .clamp(start+1, bins) with
  min > max (hard panic) once start hit bins. Verified by a standalone sweep
  over sample_rates 80..=200, windows 256/512, bars 1..256.
- src/layout/parser.rs: reject ratios whose weights overflow u32 when summed
  (checked_add), and cap split nesting at 64 so a pathological layout fails
  cleanly instead of exhausting the stack. Render sites use saturating_add
  as a second line of defense.
- src/ui/library.rs: weighted column widths computed in u64; a maximum-weight
  column on a full-width pane used to overflow the u32 budget multiply.
- src/visualizer/render.rs: a bar whose height divides exactly no longer
  draws a spurious '*' tip cell past its exact height.

Tests: 80 on unix (78 on Windows: 2 visualizer tests are cfg(unix)-gated).
Clippy clean for the music-tui crate; fmt clean on pinned 2-space style.
