### PR TITLE
fs hygiene: shared atomic writes, symlink-safe log, wider link hashes

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -368,7 +368,7 @@ impl App {
       self.set_message(format!("save failed: {error}"));
       return;
     }
-    match std::fs::write(&target, body) {
+    match crate::fsutil::atomic_write_bytes(&target, body.as_bytes()) {
       Ok(()) => self.set_message(format!("saved {written} song(s) to {}", target.display())),
       Err(error) => self.set_message(format!("save failed: {error}")),
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -393,14 +393,15 @@ fn toml_semantic_value(body: &str) -> Option<toml::Value> {
 }
 
 pub async fn write_bytes_atomic(path: &Path, body: &[u8]) -> Result<()> {
-  let temp = path.with_extension(format!("tmp.{}", std::process::id()));
-  fs::write(&temp, body)
+  let path = path.to_path_buf();
+  let body = body.to_vec();
+  let display = path.display().to_string();
+  // Config writes are rare and tiny: move the filesystem work off the async
+  // runtime and share the sync crash-safe path (create_new temp + replace).
+  tokio::task::spawn_blocking(move || crate::fsutil::atomic_write_bytes(&path, &body))
     .await
-    .with_context(|| format!("failed to write {}", temp.display()))?;
-  fs::rename(&temp, path)
-    .await
-    .with_context(|| format!("failed to rename {} to {}", temp.display(), path.display()))?;
-  Ok(())
+    .map_err(|error| anyhow::Error::msg(format!("config write worker failed: {error}")))?
+    .with_context(|| format!("failed to write {display}"))
 }
 #[cfg(test)]
 mod tests {

--- a/src/cover.rs
+++ b/src/cover.rs
@@ -81,12 +81,9 @@ fn extract_embedded_cover(file: &Path, covers_cache_dir: &Path) -> Result<PathBu
       .map_err(|error| format!("failed to create covers cache: {error}"))?;
     // Publish atomically: another instance (or a reader in this one) must
     // never observe a half-written image. Same digest → same bytes, so a
-    // racing writer's rename is harmless.
-    let temp = covers_cache_dir.join(format!(".{digest}.{ext}.{}.tmp", std::process::id()));
-    if let Err(error) = std::fs::write(&temp, data).and_then(|()| std::fs::rename(&temp, &path)) {
-      let _ = std::fs::remove_file(&temp);
-      return Err(format!("failed to write cover cache: {error}"));
-    }
+    // racing writer's replace is harmless.
+    crate::fsutil::atomic_write_bytes(&path, data)
+      .map_err(|error| format!("failed to write cover cache: {error}"))?;
   }
   Ok(path)
 }

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -1,0 +1,123 @@
+//! Cross-platform atomic file writes: unique `create_new` temp files plus a
+//! destination replace that overwrites on every platform. Plain `fs::rename`
+//! fails on Windows once the destination exists, so repeated saves need
+//! `MoveFileExW` there.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic per-process serial so two calls within one run never reuse a
+/// temp name; the pid distinguishes concurrent instances.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A unique temp path under `dir` for `hint` (same directory as the target,
+/// so a later rename stays on one filesystem).
+pub fn unique_temp_path(dir: &Path, hint: &str) -> PathBuf {
+  let serial = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+  dir.join(format!(".{hint}.{}.{serial}.tmp", std::process::id()))
+}
+
+/// Atomically publish `body` at `path`: write a `create_new` temp file in
+/// the same directory, sync it, then replace the destination. On failure the
+/// temp file is removed and the destination is left untouched. The
+/// destination is replaced (not just renamed), so repeated writes also work
+/// on Windows where a plain rename fails when the target already exists.
+pub fn atomic_write_bytes(path: &Path, body: &[u8]) -> io::Result<()> {
+  let dir = path.parent().unwrap_or_else(|| Path::new("."));
+  let hint = path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .unwrap_or("file");
+  let temp = unique_temp_path(dir, hint);
+  let result = (|| {
+    let mut file = std::fs::OpenOptions::new()
+      .create_new(true)
+      .write(true)
+      .open(&temp)?;
+    file.write_all(body)?;
+    file.sync_all()?;
+    replace_path(&temp, path)
+  })();
+  if result.is_err() {
+    let _ = std::fs::remove_file(&temp);
+  }
+  result
+}
+
+/// Replace `destination` with `source`, overwriting any existing file. Unix
+/// `rename` does this atomically; Windows needs `MoveFileExW`.
+pub fn replace_path(source: &Path, destination: &Path) -> io::Result<()> {
+  #[cfg(unix)]
+  {
+    std::fs::rename(source, destination)
+  }
+  #[cfg(windows)]
+  {
+    move_file_ex(source, destination)
+  }
+}
+
+#[cfg(windows)]
+fn move_file_ex(source: &Path, destination: &Path) -> io::Result<()> {
+  use std::os::windows::ffi::OsStrExt;
+  use windows_sys::Win32::Storage::FileSystem::{
+    MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+  };
+
+  let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+  let destination: Vec<u16> = destination
+    .as_os_str()
+    .encode_wide()
+    .chain(Some(0))
+    .collect();
+  let moved = unsafe {
+    MoveFileExW(
+      source.as_ptr(),
+      destination.as_ptr(),
+      MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+    )
+  };
+  if moved == 0 {
+    Err(io::Error::last_os_error())
+  } else {
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn temp_names_are_unique_per_call() {
+    let dir = std::env::temp_dir().join(format!("music-tui-fsutil-{}", std::process::id()));
+    let first = unique_temp_path(&dir, "state");
+    let second = unique_temp_path(&dir, "state");
+    assert_ne!(first, second);
+  }
+
+  #[test]
+  fn atomic_write_replaces_existing_destination() {
+    let dir = std::env::temp_dir().join(format!("music-tui-fsutil-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("state.toml");
+    std::fs::write(&path, b"old").unwrap();
+
+    atomic_write_bytes(&path, b"new").unwrap();
+
+    assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    let leftovers: Vec<PathBuf> = std::fs::read_dir(&dir)
+      .unwrap()
+      .filter_map(|entry| entry.ok())
+      .map(|entry| entry.path())
+      .filter(|p| p.extension().is_some_and(|ext| ext == "tmp"))
+      .collect();
+    assert!(
+      leftovers.is_empty(),
+      "no temp files may be left behind, found: {leftovers:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -197,7 +197,7 @@ pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
   std::fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
   let mut hasher = Sha256::new();
   hasher.update(target.to_string_lossy().as_bytes());
-  let hash = hex::encode(&hasher.finalize()[..4]);
+  let hash = hex::encode(&hasher.finalize()[..8]);
   let name = target.file_name().unwrap_or_default();
   let link = dir.join(format!("{hash}-{}", name.to_string_lossy()));
   if std::fs::read_link(&link).is_ok_and(|current| current == target) {
@@ -217,7 +217,7 @@ pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
     let _ = std::fs::remove_file(&temp);
     std::os::unix::fs::symlink(target, &temp)
       .with_context(|| format!("failed to link {} -> {}", temp.display(), target.display()))?;
-    if let Err(error) = std::fs::rename(&temp, &link) {
+    if let Err(error) = crate::fsutil::replace_path(&temp, &link) {
       let _ = std::fs::remove_file(&temp);
       // Someone else may have renamed an identical link into place already.
       if std::fs::read_link(&link).is_ok_and(|current| current == target) {
@@ -255,7 +255,7 @@ pub fn ensure_link(dir: &Path, target: &Path) -> Result<PathBuf> {
         bail!("{} changed while it was being copied", target.display());
       }
 
-      if let Err(error) = replace_file(&temp, &link) {
+      if let Err(error) = crate::fsutil::replace_path(&temp, &link) {
         let _ = std::fs::remove_file(&temp);
         // A concurrent instance may have published the same version first.
         if same_file_version(&link, target) {
@@ -291,33 +291,6 @@ fn same_file_version(left: &Path, right: &Path) -> bool {
           .zip(right.modified().ok())
           .is_some_and(|(left, right)| left == right)
     })
-}
-
-#[cfg(windows)]
-fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
-  use std::os::windows::ffi::OsStrExt;
-  use windows_sys::Win32::Storage::FileSystem::{
-    MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
-  };
-
-  let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
-  let destination: Vec<u16> = destination
-    .as_os_str()
-    .encode_wide()
-    .chain(Some(0))
-    .collect();
-  let moved = unsafe {
-    MoveFileExW(
-      source.as_ptr(),
-      destination.as_ptr(),
-      MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-    )
-  };
-  if moved == 0 {
-    Err(std::io::Error::last_os_error())
-  } else {
-    Ok(())
-  }
 }
 
 #[cfg(test)]
@@ -373,6 +346,39 @@ mod tests {
     let refreshed = ensure_link(&bridge, &source).unwrap();
     assert_eq!(refreshed, linked);
     assert_eq!(std::fs::read(&refreshed).unwrap(), b"other");
+
+    let _ = std::fs::remove_dir_all(&root);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn same_named_sources_get_distinct_bridge_links() {
+    let root = std::env::temp_dir().join(format!("music-tui-bridge-hash-{}", std::process::id()));
+    let album_a = root.join("album-a");
+    let album_b = root.join("album-b");
+    let bridge = root.join("bridge");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&album_a).unwrap();
+    std::fs::create_dir_all(&album_b).unwrap();
+    std::fs::write(album_a.join("song.flac"), b"first album").unwrap();
+    std::fs::write(album_b.join("song.flac"), b"second album").unwrap();
+
+    let link_a = ensure_link(&bridge, &album_a.join("song.flac")).unwrap();
+    let link_b = ensure_link(&bridge, &album_b.join("song.flac")).unwrap();
+    assert_ne!(
+      link_a, link_b,
+      "distinct sources must not collide on one link"
+    );
+    assert_eq!(std::fs::read(&link_a).unwrap(), b"first album");
+    assert_eq!(std::fs::read(&link_b).unwrap(), b"second album");
+    assert_eq!(
+      std::fs::read_link(&link_a).unwrap(),
+      album_a.join("song.flac")
+    );
+    assert_eq!(
+      std::fs::read_link(&link_b).unwrap(),
+      album_b.join("song.flac")
+    );
 
     let _ = std::fs::remove_dir_all(&root);
   }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,11 +4,7 @@ use anyhow::{Context, Result};
 
 pub fn init(cache_dir: &Path) -> Result<PathBuf> {
   let path = cache_dir.join("music-tui.log");
-  let file = std::fs::OpenOptions::new()
-    .create(true)
-    .append(true)
-    .open(&path)
-    .with_context(|| format!("failed to open {}", path.display()))?;
+  let file = open_log_file(&path).with_context(|| format!("failed to open {}", path.display()))?;
   tracing_subscriber::fmt()
     .with_ansi(false)
     .with_target(false)
@@ -19,4 +15,49 @@ pub fn init(cache_dir: &Path) -> Result<PathBuf> {
     )
     .init();
   Ok(path)
+}
+
+/// Append-mode log handle that refuses symlinks: a hostile or accidental
+/// link under the cache dir must not redirect the log stream.
+#[cfg(unix)]
+fn open_log_file(path: &Path) -> std::io::Result<std::fs::File> {
+  use std::os::unix::fs::OpenOptionsExt;
+  std::fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .custom_flags(libc::O_NOFOLLOW)
+    .open(path)
+}
+
+#[cfg(windows)]
+fn open_log_file(path: &Path) -> std::io::Result<std::fs::File> {
+  if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+    return Err(std::io::Error::other(format!(
+      "refusing to open {}: the log path is a symlink",
+      path.display()
+    )));
+  }
+  std::fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(path)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn refuses_symlinked_log_path() {
+    let dir = std::env::temp_dir().join(format!("music-tui-log-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("target.log");
+    std::fs::write(&target, b"").unwrap();
+    let link = dir.join("music-tui.log");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    assert!(open_log_file(&link).is_err());
+    let _ = std::fs::remove_dir_all(&dir);
+  }
 }

--- a/src/lyrics/mod.rs
+++ b/src/lyrics/mod.rs
@@ -213,7 +213,9 @@ fn sibling_lrc_path(file: &Path) -> Option<PathBuf> {
 }
 
 fn sanitize_filename(name: &str) -> String {
-  name.replace(['/', '\0'], "_")
+  // Backslashes are directory separators on Windows (a stray one would
+  // point the cache path outside the lyrics dir); NUL is invalid anywhere.
+  name.replace(['/', '\\', '\0'], "_")
 }
 
 /// Parse LRC content; falls back to plain lines when no timestamps exist.
@@ -236,6 +238,16 @@ mod tests {
 
     let plain = parse("just\nsome lines\n").unwrap();
     assert!(matches!(plain, Lyrics::Plain(lines) if lines.len() == 2));
+  }
+
+  #[test]
+  fn sanitize_filename_strips_path_and_control_chars() {
+    assert_eq!(sanitize_filename("a\\b/c\0d"), "a_b_c_d");
+    assert_eq!(
+      sanitize_filename("Artist - Title"),
+      "Artist - Title",
+      "ordinary names survive untouched"
+    );
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod config;
 mod cover;
 mod event;
+mod fsutil;
 mod keymap;
 mod layout;
 mod library;

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,15 +50,9 @@ impl PersistedState {
 fn save_inner(state: &PersistedState, state_dir: &Path) -> std::io::Result<()> {
   std::fs::create_dir_all(state_dir)?;
   let path = state_dir.join(STATE_FILE);
-  // Pid-suffixed temp: concurrent instances never fight over one tmp file
-  // (a fixed name would let one instance's rename steal or unlink the
-  // other's bytes). Rename atomically publishes; last writer wins.
-  let temp = state_dir.join(format!("{STATE_FILE}.{}.tmp", std::process::id()));
   let text = toml::to_string_pretty(state)
     .map_err(|error| std::io::Error::other(format!("serialize state: {error}")))?;
-  std::fs::write(&temp, text.as_bytes())?;
-  std::fs::rename(&temp, &path)?;
-  Ok(())
+  crate::fsutil::atomic_write_bytes(&path, text.as_bytes())
 }
 
 impl App {


### PR DESCRIPTION
### What
- New `src/fsutil.rs` (registered in `main.rs`): `unique_temp_path` (pid + monotonic serial), `atomic_write_bytes` (`create_new` temp + `sync_all` + replace) and `replace_path` (rename on unix, `MoveFileExW(REPLACE_EXISTING)` on Windows).
- Plain `fs::rename` fails on Windows once the destination exists, so repeated saves to an existing config/state/cover file previously errored at startup (the normalized rewrite of an existing config).
- Adopt the helper in `state.rs`, `cover.rs`, `config/mod.rs` (a `spawn_blocking` wrapper with the same `pub async` signature) and the last plain `fs::write` in `commands.rs` (m3u save).
- `library.rs`: drop the private Windows `replace_file` in favor of `fsutil::replace_path`; widen bridge link hashes to 8 bytes (16 hex chars) to match the cover digest width.
- `logging.rs`: refuse symlinked log paths (`O_NOFOLLOW` on unix, `symlink_metadata` guard on Windows) so the log stream cannot be redirected through the cache dir.
- `lyrics`: `sanitize_filename` also escapes backslash, which is a directory separator on Windows.

### Tests
- `fsutil` atomic-write / replace: cross-platform.
- Logging symlink rejection + distinct-named bridge links: unix-gated.
- `sanitize_filename`: cross-platform.
- Windows local run: 70 passed; unix CI adds the two gated tests.

### Out of scope
- `metadata.rs` in-place tag writes; `backup_config_file` (destination is always fresh); submodule crates.